### PR TITLE
Corrected streaming checkbox's 'id' and 'label for' values

### DIFF
--- a/server/public/partials/main.html
+++ b/server/public/partials/main.html
@@ -68,8 +68,8 @@ THE SOFTWARE.
                         <!-- STREAMING -->
                         <div class="row">
                             <div class="col-sm-10">
-                                <input id="checkbox-destruct" type="checkbox"  ng-model="upload.stream" style="display:inline-block">
-                                <label for="checkbox-destruct" style="font-weight:normal;">Streaming</label>
+                                <input id="checkbox-stream" type="checkbox"  ng-model="upload.stream" style="display:inline-block">
+                                <label for="checkbox-stream" style="font-weight:normal;">Streaming</label>
                                 <a tooltip-placement="right" tooltip="The files will not be stored on the server. Upload will begin when the remote user starts downloading.">?</a>
                             </div>
                         </div>


### PR DESCRIPTION
It's just a quick fix, I didn't checked if you are relying on `<input id=...` at some point but I'd guess not since you have ` ng-model`.