### PR TITLE
Add ca-certificates to the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ FROM debian:jessie
 MAINTAINER Charles-Antoine Mathieu
 MAINTAINER Mathieu Bodjikian
 
+RUN apt-get update && apt-get install -y ca-certificates
+
 # Create user
 RUN useradd -U -d /home/plik -m -s /bin/false plik 
 


### PR DESCRIPTION
Fix : Unable to create google API token : Post https://accounts.google.com/o/oauth2/token: x509: failed to load system roots and no roots provided