### PR TITLE
Added ShareX as a main feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Plik is a scalable & friendly temporary file upload system ( wetransfer like ) i
    - Comments : Add custom message (in Markdown format)
    - User authentication : Google / OVH
    - Upload restriction : Source IP / Token
+   - [ShareX](https://getsharex.com/) Uploader : Directly integrated into ShareX
 
 ### Version
 1.2.2


### PR DESCRIPTION
Adding ShareX as a main feature because you can select it simply in ShareX as a file uploader:

![image](https://user-images.githubusercontent.com/17984549/33290837-3f7d0bc0-d3c4-11e7-8bd7-76a0014978a3.png)


Also see [here](https://getsharex.com) in the File Uploader section for `Plik`.