### PR TITLE
Update Dockerfile to copy in plikd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@ EXPOSE 8080
 
 # Copy plik
 ADD server /home/plik/server/
-ADD clients /home/plik/clients/
+COPY plikd /home/plik/server/plikd
+
+ADD client /home/plik/clients/
 RUN chown -R plik:plik /home/plik
 RUN chmod +x /home/plik/server/plikd
 


### PR DESCRIPTION
## What's Changing?

Currently the Dockerfile is not runnable. This PR updates it so that it
1. copies `plikd`, given that it is copied from somewhere else (perhaps commit `plikd` to the repo?)
1. updats `clients` dir to `client`

## How was the change tested?
```
docker build .
```