### PR TITLE
Make one shot and password protection features optional

### DIFF
--- a/server/common/config.go
+++ b/server/common/config.go
@@ -70,6 +70,8 @@ type Configuration struct {
 
 	Authentication       bool     `json:"authentication"`
 	NoAnonymousUploads   bool     `json:"-"`
+	OneShot              bool     `json:"oneShot"`
+	ProtectedByPassword  bool     `json:"protectedByPassword"`
 	GoogleAuthentication bool     `json:"googleAuthentication"`
 	GoogleAPISecret      string   `json:"-"`
 	GoogleAPIClientID    string   `json:"-"`
@@ -109,6 +111,8 @@ func NewConfiguration() (config *Configuration) {
 	config.MaxTTL = 0
 	config.SslEnabled = false
 	config.StreamMode = true
+	config.OneShot = true
+	config.ProtectedByPassword = true
 	return
 }
 

--- a/server/handlers/createUpload.go
+++ b/server/handlers/createUpload.go
@@ -110,6 +110,12 @@ func CreateUpload(ctx *juliet.Context, resp http.ResponseWriter, req *http.Reque
 		}
 	}
 
+	if upload.OneShot && !common.Config.OneShot {
+		log.Warning("One shot downloads are not enabled.")
+		common.Fail(ctx, req, resp, "One shot downloads are not enabled.", 403)
+		return
+	}
+
 	if upload.Stream {
 		if !common.Config.StreamMode {
 			log.Warning("Stream mode is not enabled")
@@ -148,6 +154,12 @@ func CreateUpload(ctx *juliet.Context, resp http.ResponseWriter, req *http.Reque
 	// Add Authorization header to the response for convenience
 	// So clients can just copy this header into the next request
 	if upload.Password != "" {
+		if !common.Config.ProtectedByPassword {
+			log.Warning("Password protection is not enabled")
+			common.Fail(ctx, req, resp, "Password protection is not enabled", 403)
+			return
+		}
+
 		upload.ProtectedByPassword = true
 		if upload.Login == "" {
 			upload.Login = "plik"

--- a/server/plikd.cfg
+++ b/server/plikd.cfg
@@ -18,6 +18,8 @@ MaxFilePerUpload    = 1000
 
 DefaultTTL          = 2592000       # 30 days
 MaxTTL              = 2592000       # -1 => No limit
+OneShot             = true          # Allow users to make one shot downloads
+ProtectedByPassword = true          # Allow users to protect the download with a password
 
 SslEnabled          = false
 SslCert             = ""            # Path to your certificate file

--- a/server/public/partials/main.html
+++ b/server/public/partials/main.html
@@ -29,7 +29,7 @@ THE SOFTWARE.
         <!-- UPLOAD MENU -->
         <div class="tile menu" ng-if="mode == 'upload'">
             <!-- ONE SHOT -->
-            <div class="menu-item">
+            <div class="menu-item" ng-show="config.oneShot">
                 <label class="switch-input">
                     <input name="checkbox-destruct" type="checkbox" ng-model="upload.oneShot">
                     <i data-swoff-text="OFF" data-swon-text="ON"></i>
@@ -57,7 +57,7 @@ THE SOFTWARE.
                 </label>
             </div>
             <!-- PASSWORD -->
-            <div class="menu-item">
+            <div class="menu-item" ng-show="config.protectedByPassword">
                 <label class="switch-input">
                     <input name="checkbox-password" type="checkbox" ng-model="$parent.password"
                            ng-change="upload.password = ''">


### PR DESCRIPTION
This change provides a way to disable one shot downloads as well as password protection. Existing uploads are not affected. Default value stays true so existing installations are not affected.