### PR TITLE
Make all Swift connection parameters available

### DIFF
--- a/server/cmd/root.go
+++ b/server/cmd/root.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/root-gg/plik/server/data"
 
-	"github.com/root-gg/utils"
 	"github.com/spf13/cobra"
 
 	"github.com/root-gg/plik/server/common"
@@ -139,10 +138,6 @@ func startPlikServer(cmd *cobra.Command, args []string) {
 	// Overrides port if provided in command line
 	if port != 0 {
 		config.ListenPort = port
-	}
-
-	if config.Debug {
-		utils.Dump(config)
 	}
 
 	plik := server.NewPlikServer(config)

--- a/server/data/swift/swift.go
+++ b/server/data/swift/swift.go
@@ -16,7 +16,9 @@ var _ data.Backend = (*Backend)(nil)
 
 // Config describes configuration for Swift data backend
 type Config struct {
-	Username, Password, Host, ProjectName, Container string
+	swift.Connection
+
+	Container string // Swift container name
 }
 
 // NewConfig instantiate a new default configuration
@@ -109,12 +111,7 @@ func (b *Backend) auth() (err error) {
 		return
 	}
 
-	connection := &swift.Connection{
-		UserName: b.config.Username,
-		ApiKey:   b.config.Password,
-		AuthUrl:  b.config.Host,
-		Tenant:   b.config.ProjectName,
-	}
+	connection := &b.config.Connection
 
 	// Authenticate
 	err = connection.Authenticate()

--- a/server/plikd.cfg
+++ b/server/plikd.cfg
@@ -50,11 +50,16 @@ OvhApiEndpoint      = ""            # OVH api endpoint to use. Defaults to https
 #
 #   DataBackend = "swift"
 #   [DataBackendConfig]
-#       Username = "user@tld.net"
-#       Host = "https://auth.swiftauthapi.xxx/v2.0/"
-#       ProjectName = "MySwiftProject"
 #       Container = "plik"
-#       Password = "#######"
+#       AuthUrl = "https://auth.swiftauthapi.xxx/v2.0/"
+#       UserName = "user@tld.net"
+#       ApiKey = "xxxxxxxxxxxxxxxx"
+#       Domain = "domain"  // Name of the domain (v3 auth only)
+#       Tenant = "tenant"  // Name of the tenant (v2 auth only)
+#
+#       Please refer to https://github.com/ncw/swift for all
+#       connection settings available (v1/v2/v3)
+#
 #
 #   DataBackend  = "s3"
 #   [DataBackendConfig]

--- a/testing/swift/plikd.cfg
+++ b/testing/swift/plikd.cfg
@@ -9,9 +9,9 @@ ListenAddress       = "0.0.0.0"
 
 DataBackend         = "swift"
 [DataBackendConfig]
-       Host = "http://127.0.0.1:2603/auth/v1.0"
-       Username = "test:tester"
-       Password = "testing"
+       AuthUrl = "http://127.0.0.1:2603/auth/v1.0"
+       UserName = "test:tester"
+       ApiKey = "testing"
        Container = "plik"
 
 [MetadataBackendConfig]


### PR DESCRIPTION
This breaks the current configuration of the Swift data backend.

But it now exposes all ncs/swift connection parameters with the same names and it will be easier to troubleshoot issues.