### PR TITLE
Fix: Allow anonymous download when NoAnonymousUploads is set

### DIFF
--- a/webapp/js/ctrl/main.js
+++ b/webapp/js/ctrl/main.js
@@ -14,7 +14,7 @@ plik.controller('MainCtrl', ['$scope', '$api', '$config', '$route', '$location',
             .then(function (config) {
                 $scope.config = config;
                 $scope.setDefaultTTL();
-                if ( config.noAnonymousUploads ) {
+                if ( config.noAnonymousUploads && $scope.mode != 'download' ) {
                     // Redirect to login page if user is not authenticated
                     $config.getUser()
                         .then(null, function (error) {


### PR DESCRIPTION
Hello !

First I want to say thank you for your time and effort to build this project with so many features!

When I set the server up, I run into an issue.
It seems like the plik web client prevent user to list downloadable files even if the server allow it.

The bug can be reproduced by doing the following steps:
- Start a server with the default configuration except NoAnonymousUploads set to true.
- Then create a user, upload a file, copy the download link (The one like http://Plik_URL/#/?id=dowloadId), logout.
- If an anonymous user tries to see the file you just upload by visiting the page you just copy. The client front end will redirect the visitor the login form without showing him the file he can download.

The correct behavior would be to not redirect the user to the login page.

The patch is exactly doing that: If the page is a download page, consider that the user do not need to login.

If you have any question feel free to ask!