### PR TITLE
Refactor create upload and upload admin status

### DIFF
--- a/plik/client_test.go
+++ b/plik/client_test.go
@@ -300,7 +300,7 @@ func TestCreateAndGetUploadFiles(t *testing.T) {
 	}
 }
 
-func TestUploadFileNotFound(t *testing.T) {
+func TestUploadFile(t *testing.T) {
 	ps, pc := newPlikServerAndClient()
 	defer shutdown(ps)
 
@@ -314,6 +314,13 @@ func TestUploadFileNotFound(t *testing.T) {
 	_, _, err = pc.UploadFile(".")
 	require.Error(t, err, "unable to upload file")
 	require.Contains(t, err.Error(), "unhandled file mode", "unable to upload file")
+
+	dummyFilePath := "/tmp/plik.test.dummy.file"
+	_, err = os.Create(dummyFilePath)
+	require.NoError(t, err, "unable to create file")
+
+	_, _, err = pc.UploadFile(dummyFilePath)
+	require.NoError(t, err, "unable to upload file")
 }
 
 func TestRemoveFile(t *testing.T) {
@@ -347,7 +354,7 @@ func TestRemoveFileNotFound(t *testing.T) {
 
 	upload := &common.Upload{}
 	file := upload.NewFile()
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 	err = pc.removeFile(upload, file)
 	common.RequireError(t, err, "not found")
 }
@@ -358,7 +365,7 @@ func TestRemoveFileNoServer(t *testing.T) {
 
 	upload := &common.Upload{}
 	file := upload.NewFile()
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 	err := pc.removeFile(upload, file)
 	common.RequireError(t, err, "connection refused")
 }
@@ -396,7 +403,7 @@ func TestDeleteUploadNotFound(t *testing.T) {
 	require.NoError(t, err, "unable to start plik server")
 
 	upload := &common.Upload{}
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 	err = pc.removeUpload(upload)
 	common.RequireError(t, err, "not found")
 
@@ -410,7 +417,7 @@ func TestDeleteUploadNoServer(t *testing.T) {
 	defer shutdown(ps)
 
 	upload := &common.Upload{}
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 	err := pc.removeUpload(upload)
 	common.RequireError(t, err, "connection refused")
 }
@@ -445,7 +452,7 @@ func TestGetArchiveNotFound(t *testing.T) {
 	require.NoError(t, err, "unable to start plik server")
 
 	upload := &common.Upload{}
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 	_, err = pc.downloadArchive(upload)
 	common.RequireError(t, err, "not found")
 
@@ -459,7 +466,7 @@ func TestGetArchiveNoServer(t *testing.T) {
 	defer shutdown(ps)
 
 	upload := &common.Upload{}
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 	_, err := pc.downloadArchive(upload)
 	common.RequireError(t, err, "connection refused")
 }

--- a/plik/file_test.go
+++ b/plik/file_test.go
@@ -49,7 +49,7 @@ func TestNotUploadedGetFileURL(t *testing.T) {
 	common.RequireError(t, err, "upload has not been created yet")
 
 	upload.metadata = &common.Upload{}
-	upload.metadata.PrepareInsertForTests()
+	upload.metadata.InitializeForTests()
 
 	_, err = file.GetURL()
 	common.RequireError(t, err, "file has not been uploaded yet")

--- a/plik/internal_test.go
+++ b/plik/internal_test.go
@@ -109,7 +109,7 @@ func TestUploadFileNoUpload(t *testing.T) {
 	upload := &common.Upload{}
 	file := upload.NewFile()
 	file.Name = "filename"
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	_, err = pc.uploadFile(upload, file, bytes.NewBufferString("data"))
 	common.RequireError(t, err, "upload "+upload.ID+" not found")
@@ -128,7 +128,7 @@ func TestUploadFileReaderError(t *testing.T) {
 	upload := &common.Upload{}
 	file := upload.NewFile()
 	file.Name = "filename"
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	_, err = pc.uploadFile(upload, file, common.NewErrorReaderString("io error"))
 	common.RequireError(t, err, "io error")

--- a/plik/z2_e2e_config_test.go
+++ b/plik/z2_e2e_config_test.go
@@ -160,7 +160,7 @@ func TestTTLNoLimitDisabled(t *testing.T) {
 	upload.TTL = -1
 	err = upload.Create()
 	require.Error(t, err, "unable to create upload")
-	require.Contains(t, err.Error(), "cannot set infinite ttl", "invalid error")
+	require.Contains(t, err.Error(), "cannot set infinite TTL", "invalid error")
 }
 
 func TestPasswordDisabled(t *testing.T) {

--- a/server/common/file_test.go
+++ b/server/common/file_test.go
@@ -25,33 +25,9 @@ func TestFileSanitize(t *testing.T) {
 	require.Zero(t, file.BackendDetails, "invalid backend details")
 }
 
-func TestFilePrepareInsert(t *testing.T) {
-	upload := &Upload{}
-	file := &File{}
-	file.BackendDetails = "value"
-
-	err := file.PrepareInsert(nil)
-	require.Errorf(t, err, "missing upload")
-
-	err = file.PrepareInsert(upload)
-	require.Errorf(t, err, "upload not initialized")
-
-	upload.PrepareInsertForTests()
-
-	err = file.PrepareInsert(upload)
-	require.Errorf(t, err, "missing file name")
-
-	for i := 0; i < 2048; i++ {
-		file.Name += "x"
-	}
-
-	err = file.PrepareInsert(upload)
-	require.Errorf(t, err, "too long")
-
-	file.Name = "file name"
-	err = file.PrepareInsert(upload)
-	require.NoError(t, err, "too long")
-
-	require.NotNil(t, file.ID, "missing file id")
-	require.Equal(t, FileMissing, file.Status, "missing file id")
+func TestCreateFile(t *testing.T) {
+	config := NewConfiguration()
+	file, err := CreateFile(config, &Upload{}, &File{Name: "foo"})
+	RequireError(t, err, "upload not initialized")
+	require.Nil(t, file)
 }

--- a/server/common/upload_test.go
+++ b/server/common/upload_test.go
@@ -1,17 +1,12 @@
 package common
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
-
-func TestUploadCreate(t *testing.T) {
-	upload := &Upload{}
-	upload.PrepareInsertForTests()
-	require.NotZero(t, upload.ID, "missing id")
-}
 
 func TestUploadNewFile(t *testing.T) {
 	upload := &Upload{}
@@ -28,7 +23,10 @@ func TestUploadSanitize(t *testing.T) {
 	upload.UploadToken = "token"
 	upload.Token = "token"
 	upload.User = "user"
-	upload.Sanitize()
+
+	config := NewConfiguration()
+	config.DownloadDomain = "download.domain"
+	upload.Sanitize(config)
 
 	require.Zero(t, upload.RemoteIP, "invalid sanitized upload")
 	require.Zero(t, upload.Login, "invalid sanitized upload")
@@ -36,6 +34,18 @@ func TestUploadSanitize(t *testing.T) {
 	require.Zero(t, upload.UploadToken, "invalid sanitized upload")
 	require.Zero(t, upload.Token, "invalid sanitized upload")
 	require.Zero(t, upload.UploadToken, "invalid sanitized upload")
+	require.Equal(t, config.DownloadDomain, upload.DownloadDomain, "invalid download domain")
+}
+
+func TestUploadSanitizeAdmin(t *testing.T) {
+	upload := &Upload{}
+	upload.NewFile()
+	upload.UploadToken = "token"
+	upload.IsAdmin = true
+
+	upload.Sanitize(NewConfiguration())
+
+	require.Equal(t, "token", upload.UploadToken, "invalid sanitized upload")
 }
 
 func TestUpload_GetFile(t *testing.T) {
@@ -62,122 +72,305 @@ func TestUpload_GetFileByReference(t *testing.T) {
 	require.Equal(t, file1, f)
 }
 
-func TestUpload_PrepareInsertTooManyFiles(t *testing.T) {
+func TestUpload_TooManyFiles(t *testing.T) {
 	config := NewConfiguration()
 	config.MaxFilePerUpload = 1
 
-	upload := &Upload{}
-	upload.NewFile()
-	upload.NewFile()
+	params := &Upload{}
+	params.NewFile()
+	params.NewFile()
 
-	err := upload.PrepareInsert(config)
+	upload, err := CreateUpload(config, params)
 	require.Errorf(t, err, "too many files")
+	require.Nil(t, upload)
 }
 
-func TestUpload_PrepareInsertNoAnonymousUploads(t *testing.T) {
-	config := NewConfiguration()
-	config.NoAnonymousUploads = true
-
-	upload := &Upload{}
-
-	err := upload.PrepareInsert(config)
-	require.Errorf(t, err, "anonymous uploads are disabled")
-}
-
-func TestUpload_PrepareInsertNoAuthentication(t *testing.T) {
-	config := NewConfiguration()
-	config.NoAnonymousUploads = true
-
-	upload := &Upload{}
-	upload.User = "user"
-
-	err := upload.PrepareInsert(config)
-	require.Errorf(t, err, "authentication is disabled")
-
-	upload = &Upload{}
-	upload.Token = "token"
-
-	err = upload.PrepareInsert(config)
-	require.Errorf(t, err, "authentication is disabled")
-}
-
-func TestUpload_PrepareInsertNoOneShot(t *testing.T) {
+func TestUpload_NoOneShot(t *testing.T) {
 	config := NewConfiguration()
 	config.OneShot = false
 
-	upload := &Upload{}
-	upload.OneShot = true
-
-	err := upload.PrepareInsert(config)
-	require.Errorf(t, err, "one shot uploads are not enabled")
+	upload, err := CreateUpload(config, &Upload{OneShot: true})
+	require.Errorf(t, err, "one shot uploads are disabled")
+	require.Nil(t, upload)
 }
 
-func TestUpload_PrepareInsertNoRemovable(t *testing.T) {
+func TestUpload_NoRemovable(t *testing.T) {
 	config := NewConfiguration()
 	config.Removable = false
 
-	upload := &Upload{}
-	upload.Removable = true
-
-	err := upload.PrepareInsert(config)
-	require.Errorf(t, err, "removable uploads are not enabled")
+	upload, err := CreateUpload(config, &Upload{Removable: true})
+	require.Errorf(t, err, "removable uploads are disabled")
+	require.Nil(t, upload)
 }
 
-func TestUpload_PrepareInsertNoStream(t *testing.T) {
+func TestUpload_NoStream(t *testing.T) {
 	config := NewConfiguration()
 	config.Stream = false
 
-	upload := &Upload{}
-	upload.Stream = true
-
-	err := upload.PrepareInsert(config)
-	require.Errorf(t, err, "stream mode is not enabled")
+	upload, err := CreateUpload(config, &Upload{Stream: true})
+	require.Errorf(t, err, "streaming uploads are disabled")
+	require.Nil(t, upload)
 }
 
-func TestUpload_PrepareInsertNoBasicAuth(t *testing.T) {
+func TestUpload_NoBasicAuth(t *testing.T) {
 	config := NewConfiguration()
 	config.ProtectedByPassword = false
 
-	upload := &Upload{}
-	upload.Login = "login"
-	upload.Password = "password"
-
-	err := upload.PrepareInsert(config)
-	require.Errorf(t, err, "password protection is not enabled")
+	upload, err := CreateUpload(config, &Upload{Login: "login", Password: "password"})
+	require.Errorf(t, err, "basic auth uploads are disabled")
+	require.Nil(t, upload)
 }
 
-func TestUpload_PrepareInsertTTL(t *testing.T) {
+func TestCreateUpload(t *testing.T) {
 	config := NewConfiguration()
 
-	upload := &Upload{}
-	upload.TTL = -1
-	err := upload.PrepareInsert(config)
-	require.Errorf(t, err, "cannot set infinite ttl")
+	params := &Upload{}
 
-	upload = &Upload{}
-	upload.TTL = 2592000 + 1
-	err = upload.PrepareInsert(config)
-	require.Errorf(t, err, "invalid ttl")
+	params.ID = "id"
+	params.UploadToken = "token"
+	params.IsAdmin = true
+	params.ProtectedByPassword = true
+	params.RemoteIP = "1.3.3.7"
+	params.CreatedAt = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	deadline := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	params.ExpireAt = &deadline
 
-	upload = &Upload{}
-	upload.TTL = -10
-	err = upload.PrepareInsert(config)
-	require.Errorf(t, err, "invalid ttl")
+	file := params.NewFile()
+	file.Name = "name"
+	file.ID = "id"
+	file.Type = "type"
+	file.Size = 1234
+	file.UploadID = "upload_id"
+	file.Reference = "reference"
+	file.Status = FileUploaded
+	file.CreatedAt = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	file.Md5 = "md5sum"
+	file.BackendDetails = "details"
+
+	upload, err := CreateUpload(config, params)
+	require.NoError(t, err, "unable to create default upload")
+	require.NotNil(t, upload)
+	require.NotEmpty(t, upload.ID, "missing upload id")
+	require.NotEqual(t, params.ID, upload.ID, "invalid upload id")
+	require.Emptyf(t, upload.RemoteIP, "invalid remote IP")
+	require.NotEqual(t, params.UploadToken, upload.UploadToken, "invalid upload token")
+	require.NotEqual(t, params.CreatedAt, upload.CreatedAt, "invalid created at")
+	require.NotEqual(t, params.ExpireAt, upload.ExpireAt, "invalid expired at")
+	require.False(t, upload.IsAdmin, "invalid admin status")
+	require.False(t, upload.ProtectedByPassword, "invalid protected by password status")
+	require.Len(t, upload.Files, 1, "invalid file count")
+
+	require.NotEmpty(t, upload.Files[0].ID, "empty file id")
+	require.NotEqual(t, file.ID, upload.Files[0].ID, "invalid file id")
+	require.Equal(t, upload.ID, upload.Files[0].UploadID, "invalid file id")
+	require.Equal(t, file.Name, upload.Files[0].Name, "invalid file name")
+	require.Equal(t, file.Type, upload.Files[0].Type, "invalid file type")
+	require.Equal(t, file.Size, upload.Files[0].Size, "invalid file size")
+	require.Equal(t, file.Reference, upload.Files[0].Reference, "invalid file reference")
+	require.Equal(t, FileMissing, upload.Files[0].Status, "invalid file status")
+	require.Emptyf(t, upload.Files[0].Md5, "invalid file md5 status")
+	require.Emptyf(t, upload.Files[0].BackendDetails, "invalid file md5 status")
+	require.NotEqual(t, file.CreatedAt, upload.Files[0].CreatedAt, "invalid file created at")
+
 }
 
-func TestUpload_PrepareInsert(t *testing.T) {
+func TestCreateUploadTooManyFiles(t *testing.T) {
 	config := NewConfiguration()
+	config.MaxFilePerUpload = 2
 
-	upload := &Upload{}
-	upload.NewFile().Name = "file"
-	err := upload.PrepareInsert(config)
+	params := &Upload{}
+
+	for i := 0; i < 10; i++ {
+		fileToUpload := &File{}
+		fileToUpload.Reference = strconv.Itoa(i)
+		params.Files = append(params.Files, fileToUpload)
+	}
+
+	upload, err := CreateUpload(config, params)
+
+	RequireError(t, err, "too many files")
+	require.Nil(t, upload)
+}
+
+func TestCreateUploadOneShotWhenOneShotIsDisabled(t *testing.T) {
+	config := NewConfiguration()
+	config.OneShot = false
+
+	params := &Upload{OneShot: true}
+
+	upload, err := CreateUpload(config, params)
+	RequireError(t, err, "one shot uploads are not enabled")
+	require.Nil(t, upload)
+}
+
+func TestCreateUploadOneShotWhenRemovableIsDisabled(t *testing.T) {
+	config := NewConfiguration()
+	config.Removable = false
+
+	params := &Upload{Removable: true}
+
+	upload, err := CreateUpload(config, params)
+	RequireError(t, err, "removable uploads are not enabled")
+	require.Nil(t, upload)
+}
+
+func TestCreateUploadStreamWhenStreamIsDisabled(t *testing.T) {
+	config := NewConfiguration()
+	config.Stream = false
+
+	params := &Upload{Stream: true}
+
+	upload, err := CreateUpload(config, params)
+	RequireError(t, err, "stream mode is not enabled")
+	require.Nil(t, upload)
+}
+
+func TestCreateUploadDefaultTTL(t *testing.T) {
+	config := NewConfiguration()
+	config.DefaultTTL = 60
+
+	params := &Upload{TTL: 0}
+
+	upload, err := CreateUpload(config, params)
 	require.NoError(t, err)
+	require.NotNil(t, upload)
+	require.Equal(t, 60, upload.TTL)
+
+	require.NotNil(t, upload.CreatedAt)
+	require.True(t, upload.CreatedAt.After(time.Now().Add(-1*time.Second)))
+	require.True(t, upload.CreatedAt.Before(time.Now().Add(1*time.Second)))
+
+	require.NotNil(t, upload.ExpireAt)
+	require.True(t, upload.ExpireAt.After(time.Now().Add(59*time.Second)))
+	require.True(t, upload.ExpireAt.Before(time.Now().Add(61*time.Second)))
+}
+
+func TestCreateTTLTooLong(t *testing.T) {
+	config := NewConfiguration()
+	config.MaxTTL = 60
+
+	params := &Upload{TTL: 120}
+
+	upload, err := CreateUpload(config, params)
+	RequireError(t, err, "invalid TTL. (maximum allowed")
+	require.Nil(t, upload)
+}
+
+func TestCreateInvalidNegativeTTL(t *testing.T) {
+	config := NewConfiguration()
+
+	params := &Upload{TTL: -10}
+
+	upload, err := CreateUpload(config, params)
+	RequireError(t, err, "invalid TTL")
+	require.Nil(t, upload)
+}
+
+func TestCreateInfiniteTTL(t *testing.T) {
+	config := NewConfiguration()
+	config.MaxTTL = -1
+
+	params := &Upload{TTL: -1}
+
+	upload, err := CreateUpload(config, params)
+	require.NoError(t, err)
+	require.NotNil(t, upload)
+	require.Nil(t, upload.ExpireAt)
+}
+
+func TestCreateInvalidInfiniteTTL(t *testing.T) {
+	config := NewConfiguration()
+
+	params := &Upload{TTL: -1}
+
+	upload, err := CreateUpload(config, params)
+	RequireError(t, err, "cannot set infinite TTL")
+	require.Nil(t, upload)
+}
+
+func TestCreateWithPasswordWhenPasswordIsNotEnabled(t *testing.T) {
+	config := NewConfiguration()
+	config.ProtectedByPassword = false
+
+	params := &Upload{Login: "foo", Password: "bar"}
+
+	upload, err := CreateUpload(config, params)
+	RequireError(t, err, "password protection is not enabled")
+	require.Nil(t, upload)
+}
+
+func TestCreateWithBasicAuth(t *testing.T) {
+	config := NewConfiguration()
+
+	params := &Upload{Login: "foo", Password: "bar"}
+
+	upload, err := CreateUpload(config, params)
+	require.NoError(t, err)
+	require.NotNil(t, upload)
+	require.Equal(t, params.Login, upload.Login)
+	require.NotEqual(t, params.Password, upload.Password)
+	require.True(t, upload.ProtectedByPassword)
+}
+
+func TestCreateWithBasicAuthDefaultLogin(t *testing.T) {
+	config := NewConfiguration()
+
+	params := &Upload{Password: "bar"}
+
+	upload, err := CreateUpload(config, params)
+	require.NoError(t, err)
+	require.NotNil(t, upload)
+	require.Equal(t, "plik", upload.Login)
+	require.NotEqual(t, params.Password, upload.Password)
+	require.True(t, upload.ProtectedByPassword)
+
+}
+
+func TestCreateMissingFilename(t *testing.T) {
+	config := NewConfiguration()
+
+	params := &Upload{}
+	params.NewFile()
+
+	upload, err := CreateUpload(config, params)
+	RequireError(t, err, "missing file name")
+	require.Nil(t, upload)
+}
+
+func TestCreateWithFilenameTooLong(t *testing.T) {
+	config := NewConfiguration()
+
+	params := &Upload{}
+
+	file := &File{}
+	params.Files = append(params.Files, file)
+	for i := 0; i < 2048; i++ {
+		file.Name += "x"
+	}
+
+	upload, err := CreateUpload(config, params)
+	RequireError(t, err, "too long")
+	require.Nil(t, upload)
+}
+
+func TestCreateWithFileTooBig(t *testing.T) {
+	config := NewConfiguration()
+	config.MaxFileSize = 1024
+
+	params := &Upload{}
+
+	file := &File{Name: "foo", Size: 10 * 1024}
+	params.Files = append(params.Files, file)
+
+	upload, err := CreateUpload(config, params)
+	RequireError(t, err, "is too big")
+	require.Nil(t, upload)
 }
 
 func TestUpload_PrepareInsertForTests(t *testing.T) {
 	upload := &Upload{}
 	upload.NewFile().Name = "file"
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	require.NotZero(t, upload.ID)
 	require.NotZero(t, upload.Files[0].ID)

--- a/server/common/user_test.go
+++ b/server/common/user_test.go
@@ -23,3 +23,11 @@ func TestUser_String(t *testing.T) {
 	user.Email = "user@root.gg"
 	fmt.Println(user.String())
 }
+
+func TestIsValidProvider(t *testing.T) {
+	require.True(t, IsValidProvider(ProviderLocal))
+	require.True(t, IsValidProvider(ProviderGoogle))
+	require.True(t, IsValidProvider(ProviderOVH))
+	require.False(t, IsValidProvider(""))
+	require.False(t, IsValidProvider("foo"))
+}

--- a/server/context/admin_test.go
+++ b/server/context/admin_test.go
@@ -1,0 +1,20 @@
+package context
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/root-gg/plik/server/common"
+)
+
+func TestContext_IsAdmin(t *testing.T) {
+	ctx := &Context{}
+	require.False(t, ctx.IsAdmin())
+
+	ctx.user = &common.User{}
+	require.False(t, ctx.IsAdmin())
+
+	ctx.user.IsAdmin = true
+	require.True(t, ctx.IsAdmin())
+}

--- a/server/context/context.go
+++ b/server/context/context.go
@@ -27,7 +27,6 @@ type Context struct {
 	user                *common.User
 	token               *common.Token
 	isWhitelisted       *bool
-	isUploadAdmin       bool
 	isRedirectOnFailure bool
 	isQuick             bool
 	req                 *http.Request
@@ -253,22 +252,6 @@ func (ctx *Context) SetToken(token *common.Token) {
 	defer ctx.mu.Unlock()
 
 	ctx.token = token
-}
-
-// IsUploadAdmin get isUploadAdmin from the context.
-func (ctx *Context) IsUploadAdmin() bool {
-	ctx.mu.RLock()
-	defer ctx.mu.RUnlock()
-
-	return ctx.isUploadAdmin
-}
-
-// SetUploadAdmin set isUploadAdmin in the context
-func (ctx *Context) SetUploadAdmin(isUploadAdmin bool) {
-	ctx.mu.Lock()
-	defer ctx.mu.Unlock()
-
-	ctx.isUploadAdmin = isUploadAdmin
 }
 
 // IsRedirectOnFailure get isRedirectOnFailure from the context.

--- a/server/context/gen.pl
+++ b/server/context/gen.pl
@@ -24,7 +24,6 @@ my $struct = [
 	'token', '*common.Token', {},
 
 	'isWhitelisted', '*bool', { internal => 1 },
-	'isUploadAdmin', 'bool', {},
 	'isRedirectOnFailure', 'bool', {},
 	'isQuick', 'bool', {},
 

--- a/server/context/upload.go
+++ b/server/context/upload.go
@@ -1,24 +1,35 @@
 package context
 
-import "github.com/root-gg/plik/server/common"
+import (
+	"fmt"
+
+	"github.com/root-gg/plik/server/common"
+)
 
 // ConfigureUploadFromContext assign context values to upload
-func (ctx *Context) ConfigureUploadFromContext(upload *common.Upload) {
+// This can't be in common.Upload because of common <-> context circular dependency
+func (ctx *Context) ConfigureUploadFromContext(upload *common.Upload) (err error) {
 	if ctx.GetSourceIP() != nil {
 		// Set upload remote IP
 		upload.RemoteIP = ctx.GetSourceIP().String()
 	}
 
-	// Set upload user and token
 	user := ctx.GetUser()
-	if user != nil {
+	if user == nil {
+		if ctx.GetConfig().NoAnonymousUploads {
+			return fmt.Errorf("anonymous uploads are disabled")
+		}
+	} else {
+		if !ctx.GetConfig().Authentication {
+			return fmt.Errorf("authentication is disabled")
+		}
+
 		upload.User = user.ID
 		token := ctx.GetToken()
 		if token != nil {
-			token := ctx.GetToken()
-			if token != nil {
-				upload.Token = token.Token
-			}
+			upload.Token = token.Token
 		}
 	}
+
+	return nil
 }

--- a/server/context/upload_test.go
+++ b/server/context/upload_test.go
@@ -1,0 +1,61 @@
+package context
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/root-gg/plik/server/common"
+)
+
+func TestContext_ConfigureUploadFromContext(t *testing.T) {
+	config := common.NewConfiguration()
+
+	upload := &common.Upload{}
+	ctx := &Context{}
+	ctx.SetConfig(config)
+	ctx.SetSourceIP(net.IPv4(byte(1), byte(1), byte(1), byte(1)))
+
+	err := ctx.ConfigureUploadFromContext(upload)
+	require.NoError(t, err, "unable to configure upload from context")
+	require.Equal(t, "1.1.1.1", upload.RemoteIP, "invalid source IP address")
+}
+
+func TestContext_ConfigureUploadUser(t *testing.T) {
+	config := common.NewConfiguration()
+	config.Authentication = true
+
+	upload := &common.Upload{}
+	ctx := &Context{}
+	ctx.SetConfig(config)
+	ctx.SetUser(&common.User{ID: "foo"})
+
+	err := ctx.ConfigureUploadFromContext(upload)
+	require.NoError(t, err, "anonymous uploads are disabled")
+	require.Equal(t, "foo", upload.User, "invalid upload user")
+}
+
+func TestContext_ConfigureUploadUserAuthDisable(t *testing.T) {
+	config := common.NewConfiguration()
+
+	upload := &common.Upload{}
+	ctx := &Context{}
+	ctx.SetConfig(config)
+	ctx.SetUser(&common.User{ID: "foo"})
+
+	err := ctx.ConfigureUploadFromContext(upload)
+	require.Error(t, err, "missing authentication is disabled error")
+}
+
+func TestContext_NoAnonymousUploads(t *testing.T) {
+	config := common.NewConfiguration()
+	config.NoAnonymousUploads = true
+
+	upload := &common.Upload{}
+	ctx := &Context{}
+	ctx.SetConfig(config)
+
+	err := ctx.ConfigureUploadFromContext(upload)
+	require.Errorf(t, err, "missing no anonymous uploads error")
+}

--- a/server/data/file/file_test.go
+++ b/server/data/file/file_test.go
@@ -54,7 +54,7 @@ func TestAddFileImpossibleToCreateDirectory(t *testing.T) {
 
 	upload := &common.Upload{}
 	file := upload.NewFile()
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	err := backend.AddFile(file, &bytes.Buffer{})
 	require.Error(t, err, "unable to create directory")
@@ -66,7 +66,7 @@ func TestAddFileInvalidReader(t *testing.T) {
 
 	upload := &common.Upload{}
 	file := upload.NewFile()
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	reader := common.NewErrorReader(errors.New("io error"))
 	err := backend.AddFile(file, reader)
@@ -80,7 +80,7 @@ func TestAddFile(t *testing.T) {
 
 	upload := &common.Upload{}
 	file := upload.NewFile()
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	reader := bytes.NewBufferString("data")
 	err := backend.AddFile(file, reader)
@@ -104,7 +104,7 @@ func TestGetFileInvalidDirectory(t *testing.T) {
 
 	upload := &common.Upload{}
 	file := upload.NewFile()
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	// null byte looks like a good invalid dirname value ^^
 	backend.Config.Directory = string([]byte{0})
@@ -119,7 +119,7 @@ func TestGetFileMissingFile(t *testing.T) {
 
 	upload := &common.Upload{}
 	file := upload.NewFile()
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	_, err := backend.GetFile(file)
 	require.Error(t, err, "no error with missing file")
@@ -132,7 +132,7 @@ func TestGetFile(t *testing.T) {
 
 	upload := &common.Upload{}
 	file := upload.NewFile()
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	reader := bytes.NewBufferString("data")
 	err := backend.AddFile(file, reader)
@@ -152,7 +152,7 @@ func TestGetFileCompathPath(t *testing.T) {
 
 	upload := &common.Upload{}
 	file := upload.NewFile()
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	reader := bytes.NewBufferString("data")
 	dir := fmt.Sprintf("%s/%s/%s", backend.Config.Directory, file.UploadID[:2], file.UploadID)
@@ -184,7 +184,7 @@ func TestRemoveFileInvalidDirectory(t *testing.T) {
 
 	upload := &common.Upload{}
 	file := upload.NewFile()
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	// null byte looks like a good invalid dirname value ^^
 	backend.Config.Directory = string([]byte{0})
@@ -199,7 +199,7 @@ func TestRemoveFileMissingFile(t *testing.T) {
 
 	upload := &common.Upload{}
 	file := upload.NewFile()
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	err := backend.RemoveFile(file)
 	require.NoError(t, err, "error removing missing file")
@@ -211,7 +211,7 @@ func TestRemoveFile(t *testing.T) {
 
 	upload := &common.Upload{}
 	file := upload.NewFile()
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	reader := bytes.NewBufferString("data")
 	err := backend.AddFile(file, reader)
@@ -240,7 +240,7 @@ func TestRemoveFileTwice(t *testing.T) {
 
 	upload := &common.Upload{}
 	file := upload.NewFile()
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	reader := bytes.NewBufferString("data")
 	err := backend.AddFile(file, reader)
@@ -272,7 +272,7 @@ func TestRemoveFileCompatPath(t *testing.T) {
 
 	upload := &common.Upload{}
 	file := upload.NewFile()
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	reader := bytes.NewBufferString("data")
 	dir := fmt.Sprintf("%s/%s/%s", backend.Config.Directory, file.UploadID[:2], file.UploadID)

--- a/server/data/stream/stream.go
+++ b/server/data/stream/stream.go
@@ -64,7 +64,7 @@ func (b *Backend) AddFile(file *common.File, stream io.Reader) (err error) {
 	return nil
 }
 
-// RemoveFile is not implemented
+// RemoveFile does not need to be implemented cleaning occurs in AddFile's defer delete
 func (b *Backend) RemoveFile(file *common.File) (err error) {
 	return nil
 }

--- a/server/data/stream/stream_test.go
+++ b/server/data/stream/stream_test.go
@@ -17,7 +17,7 @@ func TestAddGetFile(t *testing.T) {
 
 	upload := &common.Upload{}
 	file := upload.NewFile()
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -58,7 +58,7 @@ func TestRemoveFile(t *testing.T) {
 
 	upload := &common.Upload{}
 	file := upload.NewFile()
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	err := backend.RemoveFile(file)
 	require.NoError(t, err)

--- a/server/handlers/add_file.go
+++ b/server/handlers/add_file.go
@@ -30,7 +30,7 @@ func AddFile(ctx *context.Context, resp http.ResponseWriter, req *http.Request) 
 	}
 
 	// Check authorization
-	if !ctx.IsUploadAdmin() {
+	if !upload.IsAdmin {
 		ctx.Forbidden("you are not allowed to add file to this upload")
 		return
 	}
@@ -86,13 +86,9 @@ func AddFile(ctx *context.Context, resp http.ResponseWriter, req *http.Request) 
 		}
 
 		// Create a new file object
-		file = common.NewFile()
-		file.Name = fileName
-
-		// Set and verify parameters
-		err = file.PrepareInsert(upload)
+		file, err = common.CreateFile(config, upload, &common.File{Name: fileName})
 		if err != nil {
-			ctx.BadRequest(err.Error())
+			ctx.BadRequest("unable to create file : %s", err.Error())
 			return
 		}
 
@@ -164,7 +160,6 @@ func AddFile(ctx *context.Context, resp http.ResponseWriter, req *http.Request) 
 	file.Md5 = preprocessOutput.md5sum
 
 	// Update file status
-	//currentStatus = file.Status
 	if upload.Stream {
 		file.Status = common.FileDeleted
 	} else {

--- a/server/handlers/add_file_test.go
+++ b/server/handlers/add_file_test.go
@@ -63,9 +63,8 @@ func getUploadRequest(t *testing.T, upload *common.Upload, file *common.File, re
 
 func TestAddFileWithID(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
-	ctx.SetUploadAdmin(true)
 
-	upload := &common.Upload{}
+	upload := &common.Upload{IsAdmin: true}
 	file := upload.NewFile()
 	file.Name = "file"
 	createTestUpload(t, ctx, upload)
@@ -98,9 +97,8 @@ func TestAddFileWithID(t *testing.T) {
 
 func TestAddStreamFileWithID(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
-	ctx.SetUploadAdmin(true)
 
-	upload := &common.Upload{}
+	upload := &common.Upload{IsAdmin: true}
 	upload.Stream = true
 	file := upload.NewFile()
 	file.Name = "file"
@@ -134,9 +132,8 @@ func TestAddStreamFileWithID(t *testing.T) {
 
 func TestAddFileWithoutID(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
-	ctx.SetUploadAdmin(true)
 
-	upload := &common.Upload{}
+	upload := &common.Upload{IsAdmin: true}
 	createTestUpload(t, ctx, upload)
 	ctx.SetUpload(upload)
 
@@ -183,10 +180,9 @@ func TestAddFileWithoutUploadInContext(t *testing.T) {
 
 func TestAddFileNoUpload(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
-	ctx.SetUploadAdmin(true)
 
-	upload := &common.Upload{}
-	upload.PrepareInsertForTests()
+	upload := &common.Upload{IsAdmin: true}
+	upload.InitializeForTests()
 
 	name := "file"
 	reader, contentType, err := getMultipartFormData(name, bytes.NewBuffer([]byte(content)))
@@ -205,9 +201,8 @@ func TestAddFileNoUpload(t *testing.T) {
 
 func TestAddFileStatusUploading(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
-	ctx.SetUploadAdmin(true)
 
-	upload := &common.Upload{}
+	upload := &common.Upload{IsAdmin: true}
 	file := upload.NewFile()
 	file.Name = "file name"
 	file.Status = common.FileUploading
@@ -226,9 +221,8 @@ func TestAddFileStatusUploading(t *testing.T) {
 
 func TestAddFileStatusUploaded(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
-	ctx.SetUploadAdmin(true)
 
-	upload := &common.Upload{}
+	upload := &common.Upload{IsAdmin: true}
 	file := upload.NewFile()
 	file.Name = "file name"
 	file.Status = common.FileUploaded
@@ -247,9 +241,8 @@ func TestAddFileStatusUploaded(t *testing.T) {
 
 func TestAddFileStatusRemoved(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
-	ctx.SetUploadAdmin(true)
 
-	upload := &common.Upload{}
+	upload := &common.Upload{IsAdmin: true}
 	file := upload.NewFile()
 	file.Name = "file name"
 	file.Status = common.FileRemoved
@@ -268,9 +261,8 @@ func TestAddFileStatusRemoved(t *testing.T) {
 
 func TestAddFileStatusDeleted(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
-	ctx.SetUploadAdmin(true)
 
-	upload := &common.Upload{}
+	upload := &common.Upload{IsAdmin: true}
 	file := upload.NewFile()
 	file.Name = "file name"
 	file.Status = common.FileDeleted
@@ -290,7 +282,7 @@ func TestAddFileStatusDeleted(t *testing.T) {
 func TestAddFileNotAdmin(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
 
-	upload := &common.Upload{}
+	upload := &common.Upload{IsAdmin: false}
 	createTestUpload(t, ctx, upload)
 
 	req, err := http.NewRequest("POST", "/file/uploadID", bytes.NewBuffer([]byte{}))
@@ -304,9 +296,8 @@ func TestAddFileNotAdmin(t *testing.T) {
 
 func TestAddFileNoMultipartForm(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
-	ctx.SetUploadAdmin(true)
 
-	upload := &common.Upload{}
+	upload := &common.Upload{IsAdmin: true}
 	createTestUpload(t, ctx, upload)
 
 	req, err := http.NewRequest("POST", "/file/"+upload.ID, bytes.NewBuffer([]byte(content)))
@@ -321,9 +312,8 @@ func TestAddFileNoMultipartForm(t *testing.T) {
 func TestAddFileTooManyFiles(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
 	ctx.GetConfig().MaxFilePerUpload = 2
-	ctx.SetUploadAdmin(true)
 
-	upload := &common.Upload{}
+	upload := &common.Upload{IsAdmin: true}
 
 	for i := 0; i < 5; i++ {
 		upload.NewFile()
@@ -347,9 +337,8 @@ func TestAddFileTooManyFiles(t *testing.T) {
 
 func TestAddFileWithFilenameTooLong(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
-	ctx.SetUploadAdmin(true)
 
-	upload := &common.Upload{}
+	upload := &common.Upload{IsAdmin: true}
 	file := upload.NewFile()
 	createTestUpload(t, ctx, upload)
 	ctx.SetFile(nil)
@@ -372,9 +361,8 @@ func TestAddFileWithFilenameTooLong(t *testing.T) {
 
 func TestAddFileWithInvalidFileName(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
-	ctx.SetUploadAdmin(true)
 
-	upload := &common.Upload{}
+	upload := &common.Upload{IsAdmin: true}
 	file := upload.NewFile()
 	file.Name = "file name"
 	createTestUpload(t, ctx, upload)
@@ -392,9 +380,8 @@ func TestAddFileWithInvalidFileName(t *testing.T) {
 
 func TestAddFileWithEmptyName(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
-	ctx.SetUploadAdmin(true)
 
-	upload := &common.Upload{}
+	upload := &common.Upload{IsAdmin: true}
 	file := upload.NewFile()
 	createTestUpload(t, ctx, upload)
 
@@ -411,9 +398,8 @@ func TestAddFileWithEmptyName(t *testing.T) {
 
 func TestAddFileWithInvalidFieldName(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
-	ctx.SetUploadAdmin(true)
 
-	upload := &common.Upload{}
+	upload := &common.Upload{IsAdmin: true}
 	file := upload.NewFile()
 	createTestUpload(t, ctx, upload)
 
@@ -430,9 +416,8 @@ func TestAddFileWithInvalidFieldName(t *testing.T) {
 
 func TestAddFileWithNoFile(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
-	ctx.SetUploadAdmin(true)
 
-	upload := &common.Upload{}
+	upload := &common.Upload{IsAdmin: true}
 	createTestUpload(t, ctx, upload)
 
 	buffer := new(bytes.Buffer)
@@ -454,9 +439,8 @@ func TestAddFileWithNoFile(t *testing.T) {
 
 func TestAddFileInvalidMultipartData(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
-	ctx.SetUploadAdmin(true)
 
-	upload := &common.Upload{}
+	upload := &common.Upload{IsAdmin: true}
 	createTestUpload(t, ctx, upload)
 
 	req, err := http.NewRequest("POST", "/file/"+upload.ID, bytes.NewBuffer([]byte("invalid multipart data")))
@@ -514,10 +498,9 @@ func TestAddFileInvalidMultipartData(t *testing.T) {
 
 func TestAddFileQuick(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
-	ctx.SetUploadAdmin(true)
 	ctx.SetQuick(true)
 
-	upload := &common.Upload{}
+	upload := &common.Upload{IsAdmin: true}
 	createTestUpload(t, ctx, upload)
 
 	name := "file"
@@ -552,10 +535,9 @@ func TestAddFileQuickDownloadDomain(t *testing.T) {
 	require.NoError(t, err, "config initialization error")
 
 	ctx := newTestingContext(config)
-	ctx.SetUploadAdmin(true)
 	ctx.SetQuick(true)
 
-	upload := &common.Upload{}
+	upload := &common.Upload{IsAdmin: true}
 	createTestUpload(t, ctx, upload)
 
 	name := "file"
@@ -586,9 +568,8 @@ func TestAddFileQuickDownloadDomain(t *testing.T) {
 func TestAddFileTooBig(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
 	ctx.GetConfig().MaxFileSize = 5
-	ctx.SetUploadAdmin(true)
 
-	upload := &common.Upload{}
+	upload := &common.Upload{IsAdmin: true}
 	createTestUpload(t, ctx, upload)
 
 	name := "file"

--- a/server/handlers/create_upload.go
+++ b/server/handlers/create_upload.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/root-gg/plik/server/common"
 
-	"github.com/root-gg/utils"
-
 	"github.com/root-gg/plik/server/context"
 )
 
@@ -27,77 +25,60 @@ func CreateUpload(ctx *context.Context, resp http.ResponseWriter, req *http.Requ
 	req.Body = http.MaxBytesReader(resp, req.Body, 1048576)
 	body, err := ioutil.ReadAll(req.Body)
 	if err != nil {
-		ctx.BadRequest("unable to read request body", err)
+		ctx.BadRequest("unable to read request body : %s", err)
 		return
 	}
 
-	// Create upload
-	upload := &common.Upload{}
-
 	// Deserialize json body
+	uploadParams := &common.Upload{}
 	version := 0
 	if len(body) > 0 {
-		version, err = common.UnmarshalUpload(body, upload)
+		version, err = common.UnmarshalUpload(body, uploadParams)
 		if err != nil {
-			ctx.BadRequest("unable to deserialize request body : %s", err.Error())
+			ctx.BadRequest("unable to deserialize request body : %s", err)
 			return
 		}
 	}
 
-	// Assign context parameters ( ip / user / token )
-	ctx.ConfigureUploadFromContext(upload)
+	// Create upload from user params
+	upload, err := common.CreateUpload(config, uploadParams)
+	if err != nil {
+		ctx.BadRequest("unable to create upload : %s", err)
+		return
+	}
+
+	// Assign context parameters ( IP / user / token )
+	err = ctx.ConfigureUploadFromContext(upload)
+	if err != nil {
+		ctx.BadRequest("unable to create upload : %s", err)
+		return
+	}
 
 	// Update request logger prefix
 	prefix := fmt.Sprintf("%s[%s]", log.Prefix, upload.ID)
 	log.SetPrefix(prefix)
 	ctx.SetUpload(upload)
 
-	// Protect upload with HTTP basic auth
-	// Add Authorization header to the response for convenience
-	// So clients can just copy this header into the next request
-	if upload.Password != "" {
-		if upload.Login == "" {
-			upload.Login = "plik"
-		}
-
-		upload.ProtectedByPassword = true
-
-		// The Authorization header will contain the base64 version of "login:password"
-		header := common.EncodeAuthBasicHeader(upload.Login, upload.Password)
-		resp.Header().Add("Authorization", "Basic "+header)
-
-		// Save only the md5sum of this string to authenticate further requests
-		upload.Password, err = utils.Md5sum(header)
-		if err != nil {
-			ctx.BadRequest("unable to generate password hash : %s", err)
-			return
-		}
-
-	}
-
-	// Set and validate upload parameters
-	err = upload.PrepareInsert(config)
-	if err != nil {
-		ctx.BadRequest(err.Error())
-		return
-	}
-
-	// Save the metadata
+	// Save the upload to the metadata database
 	err = ctx.GetMetadataBackend().CreateUpload(upload)
 	if err != nil {
 		ctx.InternalServerError("create upload error", err)
 		return
 	}
 
-	// Remove all private information (ip, data backend details, ...) before
-	// sending metadata back to the client
-	uploadToken := upload.UploadToken
-	upload.Sanitize()
-	upload.DownloadDomain = config.DownloadDomain
-
-	// Show upload token since its an upload creation
-	upload.UploadToken = uploadToken
+	// You are admin of your own uploads
 	upload.IsAdmin = true
+
+	// Hide private information (IP, data backend details, User ID, Login/Password, ...)
+	upload.Sanitize(config)
+
+	if upload.ProtectedByPassword {
+		// Add Authorization header to the response for convenience
+		// So clients can just copy this header into the next request
+		// The Authorization header will contain the base64 version of "login:password"
+		header := common.EncodeAuthBasicHeader(uploadParams.Login, uploadParams.Password)
+		resp.Header().Add("Authorization", "Basic "+header)
+	}
 
 	// Print upload metadata in the json response.
 	bytes, err := common.MarshalUpload(upload, version)

--- a/server/handlers/get_file.go
+++ b/server/handlers/get_file.go
@@ -47,6 +47,7 @@ func GetFile(ctx *context.Context, resp http.ResponseWriter, req *http.Request) 
 
 	if req.Method == "GET" && upload.OneShot {
 		// Update file status
+		// For streaming upload the status is set to deleted by the add_file handler
 		err := ctx.GetMetadataBackend().UpdateFileStatus(file, file.Status, common.FileRemoved)
 		if err != nil {
 			ctx.InternalServerError("unable to update file status", err)
@@ -75,7 +76,7 @@ func GetFile(ctx *context.Context, resp http.ResponseWriter, req *http.Request) 
 	}
 
 	/* Additional header for disabling cache if the upload is OneShot */
-	if upload.OneShot { // If this is a one shot or stream upload we have to ensure it's downloaded only once.
+	if upload.OneShot || upload.Stream { // If this is a one shot or stream upload we have to ensure it's downloaded only once.
 		resp.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate") // HTTP 1.1
 		resp.Header().Set("Pragma", "no-cache")                                   // HTTP 1.0
 		resp.Header().Set("Expires", "0")                                         // Proxies

--- a/server/handlers/get_upload.go
+++ b/server/handlers/get_upload.go
@@ -26,14 +26,8 @@ func GetUpload(ctx *context.Context, resp http.ResponseWriter, req *http.Request
 
 	upload.Files = files
 
-	// Remove all private information (ip, data backend details, ...) before
-	// sending metadata back to the client
-	upload.Sanitize()
-	upload.DownloadDomain = config.DownloadDomain
-
-	if ctx.IsUploadAdmin() {
-		upload.IsAdmin = true
-	}
+	// Hide private information (IP, data backend details, User ID, Login/Password, ...)
+	upload.Sanitize(config)
 
 	common.WriteJSONResponse(resp, upload)
 }

--- a/server/handlers/misc_test.go
+++ b/server/handlers/misc_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -29,7 +30,7 @@ func newTestingContext(config *common.Configuration) (ctx *context.Context) {
 	metadataBackendConfig := &metadata.Config{Driver: "sqlite3", ConnectionString: "/tmp/plik.test.db", EraseFirst: true}
 	metadataBackend, err := metadata.NewBackend(metadataBackendConfig, config.NewLogger())
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("unable to initialize metadata backend : %s", err))
 	}
 	ctx.SetMetadataBackend(metadataBackend)
 

--- a/server/handlers/remove_file.go
+++ b/server/handlers/remove_file.go
@@ -16,7 +16,7 @@ func RemoveFile(ctx *context.Context, resp http.ResponseWriter, req *http.Reques
 	}
 
 	// Check authorization
-	if !upload.Removable && !ctx.IsUploadAdmin() {
+	if !upload.Removable && !upload.IsAdmin {
 		ctx.Forbidden("you are not allowed to remove files from this upload")
 		return
 	}

--- a/server/handlers/remove_file_test.go
+++ b/server/handlers/remove_file_test.go
@@ -15,16 +15,15 @@ import (
 
 func TestRemoveFile(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
-	ctx.SetUploadAdmin(true)
 
 	data := "data"
 
-	upload := &common.Upload{}
+	upload := &common.Upload{IsAdmin: true}
 	file1 := upload.NewFile()
 	file1.Name = "file1"
 	file1.Status = "uploaded"
 
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	err := createTestFile(ctx, file1, bytes.NewBuffer([]byte(data)))
 	require.NoError(t, err, "unable to create test file 1")
@@ -67,7 +66,7 @@ func TestRemoveFileNotAdmin(t *testing.T) {
 	file1 := upload.NewFile()
 	file1.Name = "file1"
 	file1.Status = "uploaded"
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	err := createTestFile(ctx, file1, bytes.NewBuffer([]byte(data)))
 	require.NoError(t, err, "unable to create test file 1")
@@ -88,15 +87,14 @@ func TestRemoveFileNotAdmin(t *testing.T) {
 
 func TestRemoveRemovedFile(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
-	ctx.SetUploadAdmin(true)
 
 	data := "data"
 
-	upload := &common.Upload{}
+	upload := &common.Upload{IsAdmin: true}
 	file := upload.NewFile()
 	file.Name = "file1"
 	file.Status = common.FileRemoved
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	err := createTestFile(ctx, file, bytes.NewBuffer([]byte(data)))
 	require.NoError(t, err, "unable to create test file 1")
@@ -167,9 +165,8 @@ func TestRemoveFileNoUpload(t *testing.T) {
 
 func TestRemoveFileNoFile(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
-	ctx.SetUploadAdmin(true)
 
-	upload := &common.Upload{}
+	upload := &common.Upload{IsAdmin: true}
 	ctx.SetUpload(upload)
 
 	req, err := http.NewRequest("DELETE", "/file/uploadID/fileID/fileName", bytes.NewBuffer([]byte{}))

--- a/server/handlers/remove_upload.go
+++ b/server/handlers/remove_upload.go
@@ -16,7 +16,7 @@ func RemoveUpload(ctx *context.Context, resp http.ResponseWriter, req *http.Requ
 	}
 
 	// Check authorization
-	if !upload.Removable && !ctx.IsUploadAdmin() {
+	if !upload.Removable && !upload.IsAdmin {
 		ctx.Forbidden("you are not allowed to remove this upload")
 		return
 	}

--- a/server/handlers/remove_upload_test.go
+++ b/server/handlers/remove_upload_test.go
@@ -17,15 +17,14 @@ import (
 
 func TestRemoveUpload(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
-	ctx.SetUploadAdmin(true)
 
 	data := "data"
 
-	upload := &common.Upload{}
+	upload := &common.Upload{IsAdmin: true}
 	file := upload.NewFile()
 	file.Name = "file"
 	file.Status = "uploaded"
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	err := createTestFile(ctx, file, bytes.NewBuffer([]byte(data)))
 	require.NoError(t, err, "unable to create test file 1")
@@ -114,10 +113,9 @@ func TestRemoveUploadNoUpload(t *testing.T) {
 
 func TestRemoveUploadDataBackendError(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
-	ctx.SetUploadAdmin(true)
 
-	upload := &common.Upload{}
-	upload.PrepareInsertForTests()
+	upload := &common.Upload{IsAdmin: true}
+	upload.InitializeForTests()
 	createTestUpload(t, ctx, upload)
 
 	ctx.SetUpload(upload)

--- a/server/metadata/upload_test.go
+++ b/server/metadata/upload_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func createUpload(t *testing.T, b *Backend, upload *common.Upload) {
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 	err := b.CreateUpload(upload)
 	require.NoError(t, err, "create upload error : %s", err)
 }

--- a/server/middleware/create_upload.go
+++ b/server/middleware/create_upload.go
@@ -16,16 +16,17 @@ func CreateUpload(ctx *context.Context, next http.Handler) http.Handler {
 			return
 		}
 
-		// Create upload
-		upload := &common.Upload{}
-
-		// Assign context parameters ( ip / user / token )
-		ctx.ConfigureUploadFromContext(upload)
-
-		// Set and validate upload parameters
-		err := upload.PrepareInsert(ctx.GetConfig())
+		// Create upload with default params
+		upload, err := common.CreateUpload(ctx.GetConfig(), &common.Upload{})
 		if err != nil {
-			ctx.BadRequest(err.Error())
+			ctx.BadRequest("unable to create upload : %s", err)
+			return
+		}
+
+		// Assign context parameters ( IP / user / token )
+		err = ctx.ConfigureUploadFromContext(upload)
+		if err != nil {
+			ctx.BadRequest("unable to create upload : %s", err)
 			return
 		}
 
@@ -36,9 +37,11 @@ func CreateUpload(ctx *context.Context, next http.Handler) http.Handler {
 			return
 		}
 
+		// You are always admin of your own uploads
+		upload.IsAdmin = true
+
 		// Save upload in the request context
 		ctx.SetUpload(upload)
-		ctx.SetUploadAdmin(true)
 
 		// Change the output of the addFile handler
 		ctx.SetQuick(true)

--- a/server/middleware/upload_test.go
+++ b/server/middleware/upload_test.go
@@ -49,7 +49,7 @@ func TestUpload(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
 
 	upload := &common.Upload{}
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	err := ctx.GetMetadataBackend().CreateUpload(upload)
 	require.NoError(t, err, "Unable to create upload")
@@ -75,7 +75,7 @@ func TestUploadExpired(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
 
 	upload := &common.Upload{}
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 	deadline := time.Now().Add(-10 * time.Minute)
 	upload.ExpireAt = &deadline
 
@@ -101,7 +101,7 @@ func TestUploadToken(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
 
 	upload := &common.Upload{}
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 	upload.UploadToken = "token"
 
 	err := ctx.GetMetadataBackend().CreateUpload(upload)
@@ -122,9 +122,9 @@ func TestUploadToken(t *testing.T) {
 	Upload(ctx, common.DummyHandler).ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code, "invalid handler response status code")
-	require.NotNil(t, upload, ctx.GetUpload(), "invalid upload from context")
+	require.NotNil(t, ctx.GetUpload(), "invalid upload from context")
 	require.Equal(t, upload.Token, ctx.GetUpload().Token, "invalid upload from context")
-	require.True(t, ctx.IsUploadAdmin(), "invalid upload admin status")
+	require.True(t, ctx.GetUpload().IsAdmin, "invalid upload admin status")
 }
 
 func TestUploadUser(t *testing.T) {
@@ -136,7 +136,7 @@ func TestUploadUser(t *testing.T) {
 	ctx.SetUser(user)
 
 	upload := &common.Upload{}
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 	upload.User = user.ID
 
 	err := ctx.GetMetadataBackend().CreateUpload(upload)
@@ -155,9 +155,9 @@ func TestUploadUser(t *testing.T) {
 	Upload(ctx, common.DummyHandler).ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code, "invalid handler response status code")
-	require.NotNil(t, upload, ctx.GetUpload(), "invalid upload from context")
+	require.NotNil(t, ctx.GetUpload(), "invalid upload from context")
 	require.Equal(t, upload.User, ctx.GetUpload().User, "invalid upload from context")
-	require.True(t, ctx.IsUploadAdmin(), "invalid upload admin status")
+	require.True(t, ctx.GetUpload().IsAdmin, "invalid upload admin status")
 }
 
 func TestUploadUserToken(t *testing.T) {
@@ -168,7 +168,7 @@ func TestUploadUserToken(t *testing.T) {
 	ctx.SetToken(token)
 
 	upload := &common.Upload{}
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 	upload.Token = token.Token
 
 	err := ctx.GetMetadataBackend().CreateUpload(upload)
@@ -189,7 +189,7 @@ func TestUploadUserToken(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code, "invalid handler response status code")
 	require.NotNil(t, upload, ctx.GetUpload(), "invalid upload from context")
 	require.Equal(t, upload.User, ctx.GetUpload().User, "invalid upload from context")
-	require.True(t, ctx.IsUploadAdmin(), "invalid upload admin status")
+	require.True(t, ctx.GetUpload().IsAdmin, "invalid upload admin status")
 }
 
 func TestUploadUserAdmin(t *testing.T) {
@@ -202,7 +202,7 @@ func TestUploadUserAdmin(t *testing.T) {
 	ctx.SetUser(user)
 
 	upload := &common.Upload{}
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	err := ctx.GetMetadataBackend().CreateUpload(upload)
 	require.NoError(t, err, "Unable to create upload")
@@ -220,9 +220,9 @@ func TestUploadUserAdmin(t *testing.T) {
 	Upload(ctx, common.DummyHandler).ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code, "invalid handler response status code")
-	require.NotNil(t, upload, ctx.GetUpload(), "invalid upload from context")
+	require.NotNil(t, ctx.GetUpload(), "invalid upload from context")
 	require.Equal(t, upload.User, ctx.GetUpload().User, "invalid upload from context")
-	require.True(t, ctx.IsUploadAdmin(), "invalid upload admin status")
+	require.True(t, ctx.GetUpload().IsAdmin, "invalid upload admin status")
 	require.True(t, ctx.IsAdmin(), "invalid admin status")
 }
 
@@ -232,7 +232,7 @@ func TestUploadPasswordMissingHeader(t *testing.T) {
 
 	upload := &common.Upload{}
 	upload.ProtectedByPassword = true
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	err := ctx.GetMetadataBackend().CreateUpload(upload)
 	require.NoError(t, err, "Unable to create upload")
@@ -258,7 +258,7 @@ func TestUploadPasswordInvalidHeader(t *testing.T) {
 
 	upload := &common.Upload{}
 	upload.ProtectedByPassword = true
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	err := ctx.GetMetadataBackend().CreateUpload(upload)
 	require.NoError(t, err, "Unable to create upload")
@@ -286,7 +286,7 @@ func TestUploadPasswordInvalidScheme(t *testing.T) {
 
 	upload := &common.Upload{}
 	upload.ProtectedByPassword = true
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	err := ctx.GetMetadataBackend().CreateUpload(upload)
 	require.NoError(t, err, "Unable to create upload")
@@ -314,7 +314,7 @@ func TestUploadPasswordInvalidPassword(t *testing.T) {
 
 	upload := &common.Upload{}
 	upload.ProtectedByPassword = true
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	err := ctx.GetMetadataBackend().CreateUpload(upload)
 	require.NoError(t, err, "Unable to create upload")
@@ -346,7 +346,7 @@ func TestUploadPassword(t *testing.T) {
 	upload.ProtectedByPassword = true
 	upload.Login = "login"
 	upload.Password = "password"
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	// The Authorization header will contain the base64 version of "login:password"
 	// Save only the md5sum of this string to authenticate further requests
@@ -374,5 +374,5 @@ func TestUploadPassword(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code, "invalid handler response status code")
 	require.NotNil(t, ctx.GetUpload(), "missing upload from context")
 	require.Equal(t, upload.ID, ctx.GetUpload().ID, "invalid upload from context")
-	require.False(t, ctx.IsUploadAdmin(), "invalid upload admin status")
+	require.False(t, upload.IsAdmin, "invalid upload admin status")
 }

--- a/server/server/server_test.go
+++ b/server/server/server_test.go
@@ -144,7 +144,7 @@ func TestDataBackend(t *testing.T) {
 	upload := &common.Upload{}
 	file := upload.NewFile()
 	file.Status = common.FileUploaded
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	content := "data data data"
 	err := ps.dataBackend.AddFile(file, bytes.NewBufferString(content))
@@ -180,7 +180,7 @@ func TestClean(t *testing.T) {
 	upload.TTL = 1
 	deadline := time.Now().Add(-10 * time.Minute)
 	upload.ExpireAt = &deadline
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	require.True(t, upload.IsExpired(), "upload should be expired")
 
@@ -211,7 +211,7 @@ func TestCleanUploadingFiles(t *testing.T) {
 	upload.TTL = 1
 	deadline := time.Now().Add(-10 * time.Minute)
 	upload.ExpireAt = &deadline
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	require.True(t, upload.IsExpired(), "upload should be expired")
 
@@ -247,7 +247,7 @@ func TestAutoClean(t *testing.T) {
 	upload.TTL = 1
 	deadline := time.Now().Add(-10 * time.Minute)
 	upload.ExpireAt = &deadline
-	upload.PrepareInsertForTests()
+	upload.InitializeForTests()
 
 	require.True(t, upload.IsExpired(), "upload should be expired")
 


### PR DESCRIPTION
Refactor how uploads and files are created so that user input can't
   mess with upload parameters
 - Refactor how upload admin status is managed (kill ctx.IsUploadAdmin)
 - Ignorge IsAdmin and DownloadDomain fields/column in the metadata database
   -> No SQL schema migration needed, old DB will keep the
      extra columns but won't use them
 - Renamed Upload and File PrepareInsert() to Initialize()
 - Improved Upload and File Sanitize()
 - Improve testing and coverage