### PR TITLE
Add support to copy to clipboard

### DIFF
--- a/webapp/Gruntfile.js
+++ b/webapp/Gruntfile.js
@@ -34,7 +34,8 @@ module.exports = function (grunt) {
                     'bower_components/filesize/lib/filesize.js',
                     'bower_components/zeroclipboard/dist/ZeroClipboard.js',
                     'bower_components/angular-contenteditable/angular-contenteditable.js',
-                    'bower_components/showdown/src/showdown.js'
+                    'bower_components/showdown/src/showdown.js',
+                    'bower_components/clipboard/dist/clipboard.js'
                 ],
                 dest: 'dist/js/vendor.js'
 

--- a/webapp/bower.json
+++ b/webapp/bower.json
@@ -26,6 +26,7 @@
     "ng-file-upload": "~12.2.13",
     "angular-route": "~1.8.0",
     "angular-sanitize": "~1.8.0",
-    "angular-markdown-directive": "~0.3.1"
+    "angular-markdown-directive": "~0.3.1",
+    "clipboard": "2.0.6"
   }
 }

--- a/webapp/js/app.js
+++ b/webapp/js/app.js
@@ -37,3 +37,5 @@ var plik = angular.module('plik', ['ngRoute', 'api', 'config', 'dialog', 'conten
             return "fa fa-caret-right";
         }
     });
+
+new ClipboardJS('[data-clipboard]')

--- a/webapp/partials/home.html
+++ b/webapp/partials/home.html
@@ -176,6 +176,9 @@
                         <div class="col-xs-12 col-sm-6 small file-name">
                             <div ng-repeat="file in upload.files | filter: {status: 'uploaded'}">
                                 <a href="{{getFileUrl(upload,file)}}">{{ file.fileName }}</a>
+                                <button style="background-color: transparent; border: none;" data-clipboard data-clipboard-text="{{getFileUrl(upload,file)}}">
+                                  <span class="glyphicon glyphicon-copy"></span>
+                                </button>
                         <span class="pull-right">
                             {{ humanReadableSize(file.fileSize) }}
                         </span>

--- a/webapp/partials/main.html
+++ b/webapp/partials/main.html
@@ -118,6 +118,17 @@
                 </a>
             </div>
         </div>
+        <!-- COPY LINK BUTTON -->
+        <div class="tile menu" ng-if="mode == 'download' && somethingToDownload() && !upload.stream">
+            <div class="menu-item">
+                <div>
+                    <button type="button" class="btn btn-lg btn-primary btn-block"
+                        data-clipboard data-clipboard-text="{{getZipArchiveUrl()}}">
+                        <i class="glyphicon glyphicon-copy"></i> Copy to clipboard
+                    </button>
+                </div>
+            </div>
+        </div>
         <!-- ADD FILES BUTTON -->
         <div class="tile menu" ng-if="mode == 'download' && upload.admin && !upload.stream">
             <div class="menu-item">
@@ -245,6 +256,11 @@
                                         class="glyphicon glyphicon-cloud-download"></span><span
                                         class="hidden-xs hidden-sm"> Download</span></button>
                             </a>
+                            <!-- COPY -->
+                            <button title="Copy" type="button" class="btn btn-success btn-sm hidden-xs"
+                                    data-clipboard data-clipboard-text="{{getFileUrl(file,1)}}">
+                                <span class="glyphicon glyphicon-copy"></span>
+                            </button>
                             <!-- QR CODE -->
                             <button title="Display QRCode" type="button" class="btn btn-success btn-sm hidden-xs"
                                     ng-click="displayQRCodeFile(file)">
@@ -269,6 +285,10 @@
                     <div ng-repeat="file in files"
                          ng-show="isDownloadable(file)">
                         <a href="{{getFileUrl(file)}}"> {{getFileUrl(file)}}</a>
+                        <button style="background-color: transparent; border: none;"
+                            data-clipboard data-clipboard-text="{{getFileUrl(file)}}">
+                            <span class="glyphicon glyphicon-copy"></span>
+                        </button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This add buttons or icons near the links to allow quick copy them, without having to select the links manually.

![copy](https://user-images.githubusercontent.com/8899309/147108135-d1c999ef-db05-4a59-8f91-24211099bb42.png)