### PR TITLE
Release dev build only on main repo

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -8,6 +8,7 @@ on:
 jobs:  
   test:
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'root-gg' }}
     steps:
       
     - name: Check out code into the Go module directory


### PR DESCRIPTION
This skip "Build and release rootgg/plik:dev" job on fork. This is only needed on main repo. Else it cause many spurious email notifications when pushing to master on fork.