### PR TITLE
feat: add compatibility with OpenShift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,10 +57,14 @@ RUN adduser \
     --gecos "" \
     --home "/home/plik" \
     --shell "/bin/false" \
+    --ingroup root \
     --uid "${UID}" \
     "${USER}"
 
-COPY --from=plik-builder --chown=1000:1000 /go/src/github.com/root-gg/plik/release /home/plik/
+COPY --from=plik-builder --chown=1000:root /go/src/github.com/root-gg/plik/release /home/plik/
+
+RUN chgrp -R root /home/plik \
+ && chmod -R g+ws /home/plik
 
 EXPOSE 8080
 USER plik


### PR DESCRIPTION
OpenShift is setting a random user at statup of a container. The only thing known is that this user is member of the `root` group. This commit is about adding the `plik` user to the `root` group, and then set all the files to be owned by the `root` group.

This makes the image compatible with OpenShift.