### PR TITLE
Use custom User-Agent in client library

### DIFF
--- a/plik/client.go
+++ b/plik/client.go
@@ -17,9 +17,10 @@ type Client struct {
 
 	Debug bool // Display HTTP request and response and other helpful debug data
 
-	URL           string // URL of the Plik server
-	ClientName    string // X-ClientApp HTTP Header setting
-	ClientVersion string // X-ClientVersion HTTP Header setting
+	URL             string // URL of the Plik server
+	ClientName      string // X-ClientApp HTTP Header setting
+	ClientVersion   string // X-ClientVersion HTTP Header setting
+	ClientUserAgent string // User-Agent HTTP Header setting
 
 	HTTPClient *http.Client // HTTP Client ot use to make the requests
 }
@@ -35,6 +36,7 @@ func NewClient(url string) (c *Client) {
 	// Default values for X-ClientApp and X-ClientVersion HTTP Headers
 	c.ClientName = "plik_client"
 	c.ClientVersion = runtime.GOOS + "-" + runtime.GOARCH + "-" + common.GetBuildInfo().Version
+	c.ClientUserAgent = c.ClientName + "/" + common.GetBuildInfo().Version
 
 	c.HTTPClient = NewHTTPClient(false)
 

--- a/plik/internal.go
+++ b/plik/internal.go
@@ -297,6 +297,9 @@ func (c *Client) MakeRequest(req *http.Request) (resp *http.Response, err error)
 	if c.ClientVersion != "" {
 		req.Header.Set("X-ClientVersion", c.ClientVersion)
 	}
+	if c.ClientUserAgent != "" {
+		req.Header.Set("User-Agent", c.ClientUserAgent)
+	}
 
 	// Log request
 	if c.Debug {

--- a/server/context/errors.go
+++ b/server/context/errors.go
@@ -74,7 +74,7 @@ func (ctx *Context) Recover() {
 	}
 }
 
-var userAgents = []string{"wget", "curl", "python-urllib", "libwwww-perl", "php", "pycurl", "go-http-client"}
+var userAgents = []string{"wget", "curl", "python-urllib", "libwwww-perl", "php", "pycurl", "go-http-client", "plik_client"}
 
 // Fail is a helper to generate http error responses
 func (ctx *Context) Fail(message string, err error, status int) {


### PR DESCRIPTION
Plik client library uses standard "Go-http-client/1.1" user agent
in its HTTP requests. This may cause issues when Plik server is
hosted behind a reverse proxy which filters out various User-Agent
strings used by malicious bots, "Go-http-client/1.1" being such
example.

This change adds an additional User-Agent header to Plik client
library, so it can access Plik server instances running behind
reverse proxies implementing the User-Agent filtering.