### PR TITLE
server/middleware: make SourceIP remove zone from ip addreses

### DIFF
--- a/server/middleware/source_ip.go
+++ b/server/middleware/source_ip.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 
 	"github.com/root-gg/plik/server/context"
 )
@@ -25,6 +26,8 @@ func SourceIP(ctx *context.Context, next http.Handler) http.Handler {
 				ctx.InternalServerError("unable to parse source IP address", err)
 				return
 			}
+			// remvoes zone part in case of "host%zone"
+			sourceIPstr, _, _ = strings.Cut(sourceIPstr, "%")
 		}
 
 		// Parse source IP address

--- a/server/middleware/source_ip_test.go
+++ b/server/middleware/source_ip_test.go
@@ -43,7 +43,7 @@ func TestSourceIP(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "url", &bytes.Buffer{})
 	require.NoError(t, err, "unable to create new request")
-	req.RemoteAddr = "1.1.1.1:1111"
+	req.RemoteAddr = "1.1.1.1%eth0:1111"
 
 	rr := ctx.NewRecorder(req)
 	SourceIP(ctx, common.DummyHandler).ServeHTTP(rr, req)


### PR DESCRIPTION
This fixes a bug where some requests would not be accepted if req.RemoteAddr is something like `[fe80::0:8080%eth0]`. This PR removes the `%eth0` part in SourceIP middleware.
