### PR TITLE
Fix the use of deprecated key derivation

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -58,7 +58,7 @@ func NewUploadConfig() (config *CliConfig) {
 	config.SecureOptions = make(map[string]interface{})
 	config.SecureOptions["Openssl"] = "/usr/bin/openssl"
 	config.SecureOptions["Cipher"] = "aes-256-cbc"
-	config.SecureOptions["Options"] = "-md sha256"
+	config.SecureOptions["Options"] = "-md sha512 -pbkdf2 -iter 120000"
 	config.DownloadBinary = "curl"
 	return
 }

--- a/client/crypto/openssl/config.go
+++ b/client/crypto/openssl/config.go
@@ -18,7 +18,7 @@ func NewOpenSSLBackendConfig(params map[string]interface{}) (config *Config) {
 	config = new(Config)
 	config.Openssl = "/usr/bin/openssl"
 	config.Cipher = "aes-256-cbc"
-	config.Options = "-md sha256"
+	config.Options = "-md sha512 -pbkdf2 -iter 120000"
 	utils.Assign(config, params)
 	return
 }


### PR DESCRIPTION
Use sha512 instead of sha256, faster and more secure
Follow OWASP recommendation, use 120000 iterations for PBKDF2-HMAC-SHA512