### PR TITLE
Adding TLS option, to choose TLS version

### DIFF
--- a/server/common/config.go
+++ b/server/common/config.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/url"
@@ -47,6 +48,7 @@ type Configuration struct {
 	SslEnabled bool   `json:"-"`
 	SslCert    string `json:"-"`
 	SslKey     string `json:"-"`
+	TlsVersion string `json:"-"`
 
 	NoWebInterface      bool     `json:"-"`
 	DownloadDomain      string   `json:"downloadDomain"`
@@ -360,6 +362,24 @@ func (config *Configuration) GetServerURL() *url.URL {
 	URL.Path = config.Path
 
 	return URL
+}
+
+// GetTlsVersion is a helper to get the TLS version
+func (config *Configuration) GetTlsVersion() uint16 {
+	if config.TlsVersion == "tlsv10" {
+		return tls.VersionTLS10
+	}
+	if config.TlsVersion == "tlsv11" {
+		return tls.VersionTLS11
+	}
+	if config.TlsVersion == "tlsv12" {
+		return tls.VersionTLS12
+	}
+	if config.TlsVersion == "tlsv13" {
+		return tls.VersionTLS13
+	}
+
+	return tls.VersionTLS10
 }
 
 // GetPath return the web API/UI root path

--- a/server/plikd.cfg
+++ b/server/plikd.cfg
@@ -15,6 +15,7 @@ Path                = ""               # HTTP root path
 SslEnabled          = false            # Enable SSL
 SslCert             = "plik.crt"       # Path to your certificate file
 SslKey              = "plik.key"       # Path to your certificate private key file
+TlsVersion          = "tlsv10"         # TLS version (tlsv10|tlsv11|tlsv12|tlsv13)
 NoWebInterface      = false            # Disable web user interface
 DownloadDomain      = ""               # Enforce download domain ( ex : https://dl.plik.root.gg ) ( necessary for quick upload to work )
 DownloadDomainAlias = []               # Set download domain aliases ( ex : ["http://localhost:8080","http://127.0.0.1:8080"] ) ( must config a DownloadDomain first )

--- a/server/server/server.go
+++ b/server/server/server.go
@@ -203,7 +203,7 @@ func (ps *PlikServer) start() (err error) {
 	address := ps.config.ListenAddress + ":" + strconv.Itoa(ps.config.ListenPort)
 	if ps.config.SslEnabled {
 		proto = "https"
-		tlsConfig := &tls.Config{MinVersion: tls.VersionTLS10}
+		tlsConfig := &tls.Config{MinVersion: ps.config.GetTlsVersion()}
 
 		if ps.config.SslCert == "" || ps.config.SslKey == "" {
 			return fmt.Errorf("unable to start plik server without ssl certificates")


### PR DESCRIPTION
Let the possibility to configure Minimum TLS Version. Default to TLSv1.0 (as it's for now).