### PR TITLE
Bug fixed: commas break the format in curl attachments

### DIFF
--- a/client/plik.sh
+++ b/client/plik.sh
@@ -200,7 +200,7 @@ do
     if [ "$STDIN" == true ]; then
         UPLOAD_COMMAND+="curl -s -X POST $AUTH_TOKEN_HEADER $UPLOAD_TOKEN_HEADER -F \"file=@-;filename=$FILENAME\" $PLIK_URL/file/$UPLOAD_ID"
     else
-        UPLOAD_COMMAND+="curl -s -X POST $AUTH_TOKEN_HEADER $UPLOAD_TOKEN_HEADER -F \"file=@$FILE;filename=$FILENAME\" $PLIK_URL/file/$UPLOAD_ID"
+        UPLOAD_COMMAND+="curl -s -X POST $AUTH_TOKEN_HEADER $UPLOAD_TOKEN_HEADER -F \"file=@\\\"$FILE\\\";filename=\\\"$FILENAME\\\"\" $PLIK_URL/file/$UPLOAD_ID"
     fi
 
     FILE_RESP=$(eval $UPLOAD_COMMAND)


### PR DESCRIPTION
When there's comma in the filename like "Brains, Minds, and Machines: Vision and Action.mp4", the `-F` flag in the bash is like
```bash
-F "file=@Brains, Minds, and Machines: Vision and Action.mp4;filename=Brains, Minds, and Machines: Vision and Action.mp4"
```
The comma will split the information unexpectedly. We can add double quotes to fix this problem.