### PR TITLE
fix: handle downloadDomain in uploads listing

### DIFF
--- a/server/common/utils.go
+++ b/server/common/utils.go
@@ -75,6 +75,8 @@ func WriteJSONResponse(resp http.ResponseWriter, obj interface{}) {
 		panic(fmt.Errorf("unable to serialize json response : %s", err))
 	}
 
+	resp.Header().Add("content-type", "application/json")
+
 	_, _ = resp.Write(json)
 }
 

--- a/server/handlers/admin.go
+++ b/server/handlers/admin.go
@@ -65,6 +65,11 @@ func GetUploads(ctx *context.Context, resp http.ResponseWriter, req *http.Reques
 		}
 	}
 
+	config := ctx.GetConfig()
+	for _, upload := range uploads {
+		upload.DownloadDomain = config.DownloadDomain
+	}
+
 	pagingResponse := common.NewPagingResponse(uploads, cursor)
 	common.WriteJSONResponse(resp, pagingResponse)
 }

--- a/server/handlers/me.go
+++ b/server/handlers/me.go
@@ -69,6 +69,11 @@ func GetUserUploads(ctx *context.Context, resp http.ResponseWriter, req *http.Re
 		return
 	}
 
+	config := ctx.GetConfig()
+	for _, upload := range uploads {
+		upload.DownloadDomain = config.DownloadDomain
+	}
+
 	pagingResponse := common.NewPagingResponse(uploads, cursor)
 	common.WriteJSONResponse(resp, pagingResponse)
 }

--- a/webapp/js/ctrl/admin.js
+++ b/webapp/js/ctrl/admin.js
@@ -278,7 +278,7 @@ plik.controller('AdminCtrl', ['$scope', '$api', '$config', '$dialog', '$location
             }
             return "unlimited"
         };
-        
+
         $scope.getUserMaxTTL = function (user) {
             if (user.maxTTL > 0) {
                 return getHumanReadableTTLString(user.maxTTL)
@@ -296,7 +296,11 @@ plik.controller('AdminCtrl', ['$scope', '$api', '$config', '$dialog', '$location
 
         // Get file url
         $scope.getFileUrl = function (upload, file) {
-            return $api.base + '/file/' + upload.id + '/' + file.id + '/' + file.fileName;
+            var domain = $api.base;
+            if(upload.downloadDomain) {
+                domain = upload.downloadDomain;
+            }
+            return domain + '/file/' + upload.id + '/' + file.id + '/' + file.fileName;
         };
 
         $scope.getHumanReadableTTLString = getHumanReadableTTLString;

--- a/webapp/js/ctrl/home.js
+++ b/webapp/js/ctrl/home.js
@@ -243,7 +243,11 @@ plik.controller('HomeCtrl', ['$scope', '$api', '$config', '$dialog', '$location'
 
         // Get file url
         $scope.getFileUrl = function (upload, file) {
-            return $api.base + '/file/' + upload.id + '/' + file.id + '/' + file.fileName;
+            var domain = $api.base;
+            if(upload.downloadDomain) {
+                domain = upload.downloadDomain;
+            }
+            return domain + '/file/' + upload.id + '/' + file.id + '/' + file.fileName;
         };
 
         // Compute human readable size


### PR DESCRIPTION
Hello,

Currently, when deploying Plik with a custom downloadDomain, link in the "uploads" view (user or admin) are not pointing to the correct domain.
This is fixing this problem.

Also, added a `application/json` content-type for API response to be displayed correctly in the browser.

Romain