### PR TITLE
Fix typo in utils comment

### DIFF
--- a/server/common/utils.go
+++ b/server/common/utils.go
@@ -45,7 +45,7 @@ func StripPrefix(prefix string, handler http.Handler) http.Handler {
 		return handler
 	}
 	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-		// Relative paths to javascript, css, ... imports won't work without a tailing slash
+		// Relative paths to javascript, css, ... imports won't work without a trailing slash
 		if req.URL.Path == prefix {
 			http.Redirect(resp, req, prefix+"/", http.StatusMovedPermanently)
 			return


### PR DESCRIPTION
## Summary
- correct small typo in `server/common/utils.go`

## Testing
- `go test ./...` *(fails: unable to start server and DB constraint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684bda5e7c40832fa934e90689047b88