### PR TITLE
feat: allow for exporting better audit logs from plik

### DIFF
--- a/server/common/config.go
+++ b/server/common/config.go
@@ -22,11 +22,14 @@ import (
 
 const envPrefix = "PLIKD_"
 
+var auditLogger *logger.Logger
+
 // Configuration object
 type Configuration struct {
 	Debug         bool   `json:"-"`
 	DebugRequests bool   `json:"-"`
 	LogLevel      string `json:"-"`
+	AuditLogPath  string `json:"-"`
 
 	ListenAddress  string `json:"-"`
 	ListenPort     int    `json:"-"`
@@ -281,6 +284,22 @@ func (config *Configuration) NewLogger() (log *logger.Logger) {
 		level = "DEBUG"
 	}
 	return logger.NewLogger().SetMinLevelFromString(level).SetFlags(logger.Fdate | logger.Flevel | logger.FfixedSizeLevel)
+}
+
+func (config *Configuration) NewAuditLogger() (log *logger.Logger) {
+	if auditLogger != nil {
+		return auditLogger
+	}
+	path := config.AuditLogPath
+	if path == "" {
+		return nil
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0600)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to open audit log file '%s' because: %s\n", path, err.Error()))
+	}
+	auditLogger = logger.NewLogger().SetMinLevelFromString("DEBUG").SetDateFormat("2006-01-02T15:04:05.999Z07:00").SetFlags(logger.Fdate).SetOutput(file)
+	return auditLogger
 }
 
 // GetUploadWhitelist return the parsed IP upload whitelist

--- a/server/context/context.go
+++ b/server/context/context.go
@@ -15,6 +15,7 @@ import (
 type Context struct {
 	config              *common.Configuration
 	logger              *logger.Logger
+	auditLogger         *logger.Logger
 	metadataBackend     *metadata.Backend
 	dataBackend         data.Backend
 	streamBackend       data.Backend
@@ -73,6 +74,21 @@ func (ctx *Context) SetLogger(logger *logger.Logger) {
 	defer ctx.mu.Unlock()
 
 	ctx.logger = logger
+}
+
+// SetAuditLogger set logger used for audit in the context
+func (ctx *Context) SetAuditLogger(logger *logger.Logger) {
+	ctx.mu.Lock()
+	defer ctx.mu.Unlock()
+
+	ctx.auditLogger = logger
+}
+
+func (ctx *Context) GetAuditLogger() *logger.Logger {
+	ctx.mu.RLock()
+	defer ctx.mu.RUnlock()
+
+	return ctx.auditLogger
 }
 
 // GetMetadataBackend get metadataBackend from the context.

--- a/server/middleware/log.go
+++ b/server/middleware/log.go
@@ -1,11 +1,13 @@
 package middleware
 
 import (
-	"github.com/gorilla/mux"
+	"fmt"
 	"net/http"
 	"net/http/httputil"
 	"strings"
 	"time"
+
+	"github.com/gorilla/mux"
 
 	"github.com/root-gg/plik/server/context"
 )
@@ -77,5 +79,44 @@ func Log(ctx *context.Context, next http.Handler) http.Handler {
 				log.Warningf("Unable to dump HTTP request : %s", err)
 			}
 		}
+
+	})
+}
+
+// Log the http request
+func AuditLog(ctx *context.Context, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		auditLogger := ctx.GetAuditLogger()
+		if auditLogger == nil {
+			return
+		}
+
+		statusCodeResponseWriter := newStatusCodeResponseWriter(resp)
+		ctx.SetResp(statusCodeResponseWriter)
+		next.ServeHTTP(statusCodeResponseWriter, req)
+
+		// Get the response status code
+		statusCode := statusCodeResponseWriter.statusCode
+
+		user := ctx.GetUser()
+		method := req.Method
+		uri := req.RequestURI
+		ipSrc := ctx.GetSourceIP().String()
+		file := ctx.GetFile()
+		upload := ctx.GetUpload()
+
+		log := ""
+		if user != nil {
+			log += fmt.Sprintf("user_id: %s, user_login: %s, user_email: %s, ", user.ID, user.Login, user.Email)
+		}
+		if file != nil {
+			log += fmt.Sprintf("file_name: %s, file_md5: %s, file_size: %d, mime_type: %s, upload_id: %s, ", file.Name, file.Md5, file.Size, file.Type, file.UploadID)
+		}
+		if upload != nil {
+			log += fmt.Sprintf("upload_login: %s, upload_ttl: %d, upload_upload_token: %s, upload_ip_src: %s, ", upload.Login, upload.TTL, upload.UploadToken, upload.RemoteIP)
+		}
+		log += fmt.Sprintf("method: %s, uri: %s, status_code: %d, ip_src: %s", method, uri, statusCode, ipSrc)
+
+		auditLogger.Info(log)
 	})
 }

--- a/server/middleware/log_test.go
+++ b/server/middleware/log_test.go
@@ -70,3 +70,33 @@ func TestLogDebugNoBody(t *testing.T) {
 	require.Contains(t, string(buffer.Bytes()), "POST /file", "invalid log message")
 	require.NotContains(t, string(buffer.Bytes()), "request body", "invalid log message")
 }
+
+func TestEmptyAuditLogFile(t *testing.T) {
+	ctx := newTestingContext(common.NewConfiguration())
+	auditLogger := ctx.GetAuditLogger()
+	require.Nil(t, auditLogger, "Audit logger should not exist")
+}
+
+func TestEmptyAuditLog(t *testing.T) {
+	conf := common.NewConfiguration()
+	conf.AuditLogPath = "/tmp/log"
+	ctx := newTestingContext(conf)
+	auditLogger := ctx.GetAuditLogger()
+	require.NotNil(t, auditLogger, "Audit logger should be initialized")
+
+	ctx.GetConfig().DebugRequests = true
+
+	buffer := &bytes.Buffer{}
+	auditLogger.SetOutput(buffer)
+
+	req, err := http.NewRequest("POST", "/file", bytes.NewBuffer([]byte("request body")))
+	require.NoError(t, err, "unable to create new request")
+
+	req.RequestURI = "/file"
+
+	rr := ctx.NewRecorder(req)
+	AuditLog(ctx, common.DummyHandler).ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "invalid handler response status code")
+	require.Contains(t, buffer.String(), "method: POST, uri: /file", "invalid log message")
+}

--- a/server/middleware/misc_test.go
+++ b/server/middleware/misc_test.go
@@ -12,6 +12,7 @@ func newTestingContext(config *common.Configuration) (ctx *context.Context) {
 	config.Debug = true
 	ctx.SetConfig(config)
 	ctx.SetLogger(config.NewLogger())
+	ctx.SetAuditLogger(config.NewAuditLogger())
 
 	ctx.SetDataBackend(data_test.NewBackend())
 	ctx.SetStreamBackend(data_test.NewBackend())

--- a/server/plikd.cfg
+++ b/server/plikd.cfg
@@ -6,6 +6,7 @@
 Debug               = false            # Enable debug mode
 DebugRequests       = false            # Log HTTP request and responses
 LogLevel            = "INFO"           # Log level (DEBUG|INFO|WARNING|CRITICAL)
+#AuditLogPath        = ""               # Path to the audit log
 
 ListenPort          = 8080             # Port the HTTP server will listen on
 ListenAddress       = "0.0.0.0"        # Address the HTTP server will bind on

--- a/server/server/server.go
+++ b/server/server/server.go
@@ -302,7 +302,7 @@ func (ps *PlikServer) getHTTPHandler() (handler http.Handler) {
 	emptyChain := context.NewChain(middleware.Context(ps.setupContext))
 
 	// The base middleware chain
-	stdChain := emptyChain.Append(middleware.SourceIP, middleware.Log, middleware.Recover)
+	stdChain := emptyChain.Append(middleware.SourceIP, middleware.Log, middleware.Recover, middleware.AuditLog)
 
 	// A chain that authenticates user from session cookies
 	authChain := stdChain.Append(middleware.Authenticate(false), middleware.Impersonate)
@@ -546,6 +546,7 @@ func (ps *PlikServer) GetStreamBackend() data.Backend {
 func (ps *PlikServer) setupContext(ctx *context.Context) {
 	ctx.SetConfig(ps.config)
 	ctx.SetLogger(ps.config.NewLogger())
+	ctx.SetAuditLogger(ps.config.NewAuditLogger())
 	ctx.SetMetadataBackend(ps.metadataBackend)
 	ctx.SetDataBackend(ps.dataBackend)
 	ctx.SetStreamBackend(ps.streamBackend)


### PR DESCRIPTION
Actual plik logs are not enough for a proper abuse system.
This adds a new logger that can be enabled by specifying a path in `AuditLogPath` in the config file.
The logger is using a standard timestamp with timezone and milliseconds.
The logs are easier to parse.

Log example:
```
[2025-07-23T04:23:33.171-04:00] user_id: local:username, user_login: username, user_email: , file_name: a.test, file_md5: f256e2aaafbf7358fdde734c1f263fb2, file_size: 161, mime_type: text/html; charset=utf-8, upload_id: qbhoDOt1RqmtW6jt, upload_login: , upload_ttl: 2592000, upload_upload_token: Yt6JmfsTSyh3ZUrav0zAETcyJFekPCU6, upload_ip_src: 127.0.0.1, method: GET, uri: /file/qbhoDOt1RqmtW6jt/5fLEnTb4qrx3JwlN/a, status_code: 301, ip_src: 127.0.0.1
```
The logs should not leak any secret like password or private token nor the file content.