### PR TITLE
Fix vet format string warnings

### DIFF
--- a/client/plik.go
+++ b/client/plik.go
@@ -337,7 +337,7 @@ func info(client *plik.Client) (err error) {
 	}
 
 	fmt.Printf("\nPlik server configuration :\n")
-	fmt.Printf(serverConfig.String())
+	fmt.Printf("%s", serverConfig.String())
 
 	return nil
 }

--- a/server/handlers/add_file.go
+++ b/server/handlers/add_file.go
@@ -141,7 +141,7 @@ func AddFile(ctx *context.Context, resp http.ResponseWriter, req *http.Request) 
 	cleanup := func() {
 		err := purge(ctx, file)
 		if err != nil {
-			log.Warningf(err.Error())
+			log.Warningf("%s", err.Error())
 		}
 	}
 
@@ -258,14 +258,14 @@ func preprocessor(ctx *context.Context, file io.Reader, preprocessWriter io.Writ
 		// Compute md5sum
 		_, err = md5Hash.Write(buf[:bytesRead])
 		if err != nil {
-			err = fmt.Errorf(err.Error())
+			err = fmt.Errorf("%s", err.Error())
 			break
 		}
 
 		// Forward data to the data backend
 		bytesWritten, err := preprocessWriter.Write(buf[:bytesRead])
 		if err != nil {
-			err = fmt.Errorf(err.Error())
+			err = fmt.Errorf("%s", err.Error())
 			break
 		}
 		if bytesWritten != bytesRead {

--- a/server/handlers/get_file.go
+++ b/server/handlers/get_file.go
@@ -125,7 +125,7 @@ func GetFile(ctx *context.Context, resp http.ResponseWriter, req *http.Request) 
 		// Remove the file asynchronously
 		err := purge(ctx, file)
 		if err != nil {
-			log.Warningf(err.Error())
+			log.Warningf("%s", err.Error())
 		}
 	}
 }

--- a/server/handlers/remove_file.go
+++ b/server/handlers/remove_file.go
@@ -40,7 +40,7 @@ func RemoveFile(ctx *context.Context, resp http.ResponseWriter, req *http.Reques
 	// Remove the file asynchronously
 	err = purge(ctx, file)
 	if err != nil {
-		ctx.GetLogger().Warningf(err.Error())
+		ctx.GetLogger().Warningf("%s", err.Error())
 	}
 
 	_, _ = resp.Write([]byte("ok"))

--- a/server/metadata/upload.go
+++ b/server/metadata/upload.go
@@ -267,7 +267,7 @@ func (b *Backend) DeleteRemovedUploads() (removed int, err error) {
 		})
 		if err != nil {
 			errors++
-			b.log.Warningf(err.Error())
+			b.log.Warningf("%s", err.Error())
 		} else {
 			removed++
 		}

--- a/server/server/server.go
+++ b/server/server/server.go
@@ -161,7 +161,7 @@ func (ps *PlikServer) refreshServerStatsRoutine() {
 func (ps *PlikServer) start() (err error) {
 	log := ps.config.NewLogger()
 
-	log.Infof("Starting plikd server v" + common.GetBuildInfo().Version)
+	log.Infof("Starting plikd server v%s", common.GetBuildInfo().Version)
 
 	log.Debug("Configuration :")
 	for _, line := range strings.Split(ps.config.String(), "\n") {


### PR DESCRIPTION
## Summary
- replace dynamic format strings with explicit string formats for logging and errors
- ensure client configuration output uses a constant format string to satisfy go vet

## Testing
- make lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693327ff86bc832f82b6fe36e37d62ef)