### PR TITLE
Add "Never expires" TTL option to upload sidebar

### DIFF
--- a/webapp/src/components/UploadSidebar.vue
+++ b/webapp/src/components/UploadSidebar.vue
@@ -67,6 +67,16 @@ const maxTTL = computed(() => {
   return val && val > 0 ? secondsToTTL(val) : null
 })
 
+// "Never expires" is allowed when there is no maxTTL limit
+const canNeverExpire = computed(() => {
+  const val = props.effectiveMaxTTL || config.maxTTL
+  return !val || val <= 0
+})
+
+function toggleNeverExpires() {
+  updateSetting('neverExpires', !props.settings.neverExpires)
+}
+
 const hasAnySettings = computed(() =>
   isFeatureEnabled('one_shot') ||
   isFeatureEnabled('stream') ||
@@ -205,7 +215,22 @@ const hasAnySettings = computed(() =>
     <!-- TTL Section -->
     <div v-if="isFeatureEnabled('set_ttl')" class="sidebar-section">
       <h3 class="text-xs font-semibold text-surface-400 uppercase tracking-wider mb-2">Expiration</h3>
-      <div class="flex items-center gap-2">
+
+      <!-- Never expires toggle -->
+      <label v-if="canNeverExpire"
+             class="flex items-center justify-between py-1 mb-2 cursor-pointer group">
+        <span class="text-sm text-surface-200 group-hover:text-white transition-colors">
+          Never expires
+        </span>
+        <button type="button"
+                class="toggle-switch"
+                :data-active="settings.neverExpires"
+                @click="toggleNeverExpires">
+          <span class="toggle-dot" />
+        </button>
+      </label>
+
+      <div v-if="!settings.neverExpires" class="flex items-center gap-2">
         <input type="number"
                class="input-field w-20"
                min="1"
@@ -221,7 +246,7 @@ const hasAnySettings = computed(() =>
           <option value="days">days</option>
         </select>
       </div>
-      <p v-if="maxTTL" class="text-xs text-surface-500 mt-1">
+      <p v-if="maxTTL && !settings.neverExpires" class="text-xs text-surface-500 mt-1">
         Max: {{ maxTTL.value }} {{ maxTTL.unit }}
       </p>
     </div>

--- a/webapp/src/views/UploadView.vue
+++ b/webapp/src/views/UploadView.vue
@@ -46,6 +46,8 @@ const settings = reactive({
   password: '',
   commentEnabled: isFeatureDefaultOn('comments'),
   extendTTL: isFeatureDefaultOn('extend_ttl'),
+  // When both defaultTTL and maxTTL are 0 (no limit), default to "never expires" ON (opt-out)
+  neverExpires: config.defaultTTL <= 0 && effectiveMaxTTL.value <= 0,
   ttlValue: defaultTTL.value.value || 15,
   ttlUnit: defaultTTL.value.unit || 'days',
 })
@@ -185,7 +187,7 @@ function buildUploadParams() {
     stream: settings.stream,
     removable: settings.removable,
     extend_ttl: settings.extendTTL,
-    ttl: ttlToSeconds(settings.ttlValue, settings.ttlUnit),
+    ttl: settings.neverExpires ? -1 : ttlToSeconds(settings.ttlValue, settings.ttlUnit),
   }
 
   if (settings.passwordEnabled && settings.login && settings.password) {


### PR DESCRIPTION
## Summary

Adds a "Never expires" toggle to the upload sidebar TTL section, addressing issue #541.

## Problem

When `MaxTTLStr = "0"` (no limit), the backend correctly allows infinite TTL (`ttl: -1`), but the frontend had no way to select this option. Users could only set numeric TTL values.

## Solution

Added a "Never expires" toggle that:
- Only appears when `maxTTL <= 0` (server allows infinite TTL)
- Defaults to **ON** when both `defaultTTL <= 0` and `maxTTL <= 0` (opt-out behavior)
- Defaults to **OFF** otherwise (opt-in behavior)
- Hides the TTL value/unit inputs when active
- Sends `ttl: -1` to the server when enabled

## Changes

- **`webapp/src/components/UploadSidebar.vue`**
  - Added `canNeverExpire` computed property
  - Added `toggleNeverExpires()` function
  - Added "Never expires" toggle UI
  - Conditional rendering of TTL inputs based on toggle state

- **`webapp/src/views/UploadView.vue`**
  - Added `neverExpires` setting with smart default
  - Updated `buildUploadParams()` to send `ttl: -1` when enabled

## Screenshots

**Toggle OFF** (default when TTL limits exist):
![Never expires OFF](https://github.com/user-attachments/assets/never_expires_off.png)

**Toggle ON** (hides inputs):
![Never expires ON](https://github.com/user-attachments/assets/never_expires_on.png)

**Default state when both TTLs are 0**:
![Default ON](https://github.com/user-attachments/assets/never_expires_default.png)

## Testing

- ✅ Build passes cleanly
- ✅ Toggle appears only when `maxTTL <= 0`
- ✅ Toggle defaults to ON when `defaultTTL <= 0` and `maxTTL <= 0`
- ✅ TTL inputs hide when toggle is ON
- ✅ Sends `ttl: -1` to server when enabled

Fixes #541