### PR TITLE
ci: parallelize test jobs and add make test-backend target

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,6 +1,6 @@
 name: test
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   test:
@@ -8,7 +8,7 @@ jobs:
     steps:
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -16,8 +16,7 @@ jobs:
         go-version-file: 'go.mod'
 
     - name: Fetch tags
-      run: |
-        git fetch --prune --unshallow --tags
+      run: git fetch --prune --unshallow --tags
 
     - name: Run linter
       run: make lint
@@ -25,16 +24,44 @@ jobs:
     - name: Run tests
       run: make test
 
-    - name: Run test-backends
+    - name: Install govulncheck
+      run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+    - name: Run vulnerability check (report only)
+      run: make vuln || true
+
+  test-backends:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Fetch tags
+      run: git fetch --prune --unshallow --tags
+
+    - name: Run backend tests
       run: make test-backends
 
-    - name: Set up Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: 24
+  release:
+    runs-on: ubuntu-latest
+    steps:
 
-    - name: Build documentation
-      run: make docs
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Fetch tags
+      run: git fetch --prune --unshallow --tags
 
     - name: Set up Docker Buildx
       id: buildx
@@ -43,8 +70,21 @@ jobs:
     - name: Run release
       run: make release
 
-    - name: Install govulncheck
-      run: go install golang.org/x/vuln/cmd/govulncheck@latest
+  docs:
+    runs-on: ubuntu-latest
+    steps:
 
-    - name: Run vulnerability check (report only)
-      run: make vuln || true
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 24
+        cache: npm
+        cache-dependency-path: docs/package-lock.json
+
+    - name: Build docs
+      run: make docs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,8 @@ cd server && ./plikd        # Run server on http://127.0.0.1:8080
 
 ```bash
 make test                   # Unit tests + CLI integration tests
-make test-backends           # Docker-based backend integration tests
+make test-backends           # Docker-based backend integration tests (all)
+make test-backend mariadb    # Docker-based test for a single backend
 make lint                   # go fmt + go vet
 make vuln                   # govulncheck (report only)
 ```
@@ -106,7 +107,7 @@ The documentation lives in two places:
 
 ```bash
 cd docs && npm install       # First time only
-cd docs && npx vitepress dev # Preview at localhost:5173
+cd docs && npm run dev       # Preview at localhost:5173
 make docs                    # Build docs (validates links, injects version)
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,18 @@ test-backends:
 	@testing/test_backends.sh
 
 ###
+# Run integration tests for a single backend
+# Usage: make test-backend mariadb
+###
+ifeq (test-backend,$(firstword $(MAKECMDGOALS)))
+  BACKEND_ARG := $(wordlist 2,2,$(MAKECMDGOALS))
+  $(eval $(BACKEND_ARG):;@:)
+endif
+
+test-backend:
+	@testing/test_backends.sh $(BACKEND_ARG)
+
+###
 # Build documentation
 ###
 docs:
@@ -168,4 +180,4 @@ clean-all: clean clean-frontend
 # by make, we must declare these targets as phony to avoid :
 # "make: `client' is up to date" cases at compile time
 ###
-.PHONY: client clients server release docs
+.PHONY: client clients server release docs test-backend


### PR DESCRIPTION
- Split tests.yaml into 4 parallel jobs: test, test-backends, release, docs
- Change trigger from [push, pull_request] to [pull_request] only (push to master is already handled by master.yaml)
- Add 'make test-backend <name>' Makefile target for single backend testing
- Upgrade actions/checkout from v3 to v4
- Update AGENTS.md with new test commands