### PR TITLE
fix: docs deploy build pipeline

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,13 +30,8 @@ jobs:
           cache: npm
           cache-dependency-path: docs/package-lock.json
 
-      - name: Install dependencies
-        run: npm ci
-        working-directory: docs
-
-      - name: Build VitePress site
-        run: npm run build
-        working-directory: docs
+      - name: Build docs
+        run: make docs
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -387,6 +387,12 @@ docs/
 - **Deploy**: Automated via `.github/workflows/deploy-docs.yml` on push to `master`
 - **CI**: Build is verified on every push/PR via `.github/workflows/tests.yaml`
 
+**Build pipeline** (`make docs`):
+
+1. `inject_version.sh` — replaces `__VERSION__` placeholders in markdown files with the current version from `gen_build_info.sh`. Only runs in CI (`$CI` env var); skipped locally to avoid dirtying source files.
+2. `copy_architecture.sh` — copies each `ARCHITECTURE.md` from the repo into `docs/architecture/` with cross-link rewriting. These generated files are `.gitignored`.
+3. `npm run build` — runs the VitePress build (includes dead link checking).
+
 ### Agent-Readable Docs (`ARCHITECTURE.md` files)
 
 Scoped `ARCHITECTURE.md` files placed in each package directory, designed for AI coding assistants. Each file documents internal structure, key abstractions, data flow, and design decisions. See the list below.

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,10 +1,4 @@
 node_modules
 .vitepress/dist
 .vitepress/cache
-architecture/system.md
-architecture/server.md
-architecture/client.md
-architecture/library.md
-architecture/webapp.md
-architecture/testing.md
-architecture/releaser.md
+architecture/*.md

--- a/docs/guide/docker.md
+++ b/docs/guide/docker.md
@@ -10,7 +10,7 @@ docker run -p 8080:8080 rootgg/plik
 
 Available tags:
 - `latest` — Latest stable release
-- `1.3.8` — Specific version
+- `__VERSION__` — Specific version
 - `dev` — Latest build from master branch
 
 ## Custom Configuration

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -5,9 +5,9 @@
 Download the latest release and run:
 
 ```bash
-wget https://github.com/root-gg/plik/releases/download/1.3.8/plik-1.3.8-linux-amd64.tar.gz
-tar xzvf plik-1.3.8-linux-amd64.tar.gz
-cd plik-1.3.8/server
+wget https://github.com/root-gg/plik/releases/download/__VERSION__/plik-__VERSION__-linux-amd64.tar.gz
+tar xzvf plik-__VERSION__-linux-amd64.tar.gz
+cd plik-__VERSION__/server
 ./plikd
 ```
 

--- a/docs/inject_version.sh
+++ b/docs/inject_version.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+# Only inject version in CI to avoid modifying source files locally
+if [[ -z "$CI" ]]; then
+    echo "Skipping version injection (not in CI)"
+    exit 0
+fi
+
 # Get the version from gen_build_info.sh
 VERSION=$(../server/gen_build_info.sh version)
 
@@ -12,12 +18,8 @@ fi
 
 echo "Injecting version $VERSION into documentation..."
 
-# Update getting-started.md with the current version
-sed -i "s|releases/download/[^/]*/plik-[^/]*-linux-amd64.tar.gz|releases/download/$VERSION/plik-$VERSION-linux-amd64.tar.gz|g" guide/getting-started.md
-sed -i "s|tar xzvf plik-[^/]*-linux-amd64.tar.gz|tar xzvf plik-$VERSION-linux-amd64.tar.gz|g" guide/getting-started.md
-sed -i "s|cd plik-[^/]*/server|cd plik-$VERSION/server|g" guide/getting-started.md
-
-# Update docker.md with the current version
-sed -i "s|- \`[0-9.]*\` — Specific version|- \`$VERSION\` — Specific version|g" guide/docker.md
+# Replace __VERSION__ placeholders in all markdown files
+find . -name '*.md' -not -path './node_modules/*' -not -path './vendor/*' -exec \
+    sed -i "s/__VERSION__/$VERSION/g" {} +
 
 echo "Version injection complete"


### PR DESCRIPTION
## Problem

The docs deploy workflow (`deploy-docs.yml`) was running `npm run build` directly without first running `inject_version.sh` and `copy_architecture.sh`. This caused the build to fail with a dead link error:

```
(!) Found dead link /architecture/system in file contributing.md
```

The `architecture/*.md` files are generated by `copy_architecture.sh` from the repo's `ARCHITECTURE.md` files and are `.gitignored`, so they must be generated before building.

## Changes

- **`deploy-docs.yml`**: Use `make docs` instead of bare `npm ci` + `npm run build` (aligns with how tests.yaml and the Makefile already handle it)
- **`inject_version.sh`**: Simplified to replace `__VERSION__` placeholders globally. Only runs in CI (`$CI` env var) to avoid dirtying the working tree locally
- **`getting-started.md` / `docker.md`**: Use `__VERSION__` placeholders instead of hardcoded version strings — no more commits needed per release
- **`docs/.gitignore`**: Simplified with `architecture/*.md` glob
- **`ARCHITECTURE.md`**: Documented the build pipeline steps