### PR TITLE
fix: redirect authenticated users away from login page

### DIFF
--- a/webapp/src/views/LoginView.vue
+++ b/webapp/src/views/LoginView.vue
@@ -1,11 +1,18 @@
 <script setup>
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { config } from '../config.js'
-import { login } from '../authStore.js'
+import { auth, login } from '../authStore.js'
 import { oidcLogin as apiOidcLogin } from '../api.js'
 import { useRouter } from 'vue-router'
 
 const router = useRouter()
+
+// Redirect authenticated users to the upload page
+// This handles OAuth callbacks (server redirects to /#/login after success)
+// and direct navigation to /#/login while already logged in
+onMounted(() => {
+  if (auth.user) router.replace('/')
+})
 
 const loginName = ref('')
 const password = ref('')


### PR DESCRIPTION
## Problem

When OAuth callbacks (Google, OVH, OIDC) redirect to `/#/login` after successful authentication, the user stays on the login page despite being authenticated. The header correctly shows the user info, but the login form is still displayed.

**Root cause:** In `main.js`, `app.use(router)` is called before `Promise.all([loadConfig(), checkSession()])` completes. Vue Router 4 starts resolving the initial navigation as soon as it's installed, so the `router.beforeEach` guard runs with `auth.user === null` and allows the login page through. By the time the app mounts, `auth.user` is set (header shows the user), but the route is already resolved to `/login`.

This also affects direct navigation to `/#/login` while already logged in — the guard doesn't redirect because it ran before auth state was loaded.

## Fix

Add an `onMounted` redirect in `LoginView.vue` that checks `auth.user` and redirects to `/` (the upload page). By the time the component mounts, `checkSession()` has completed via the `Promise.all` gate in `main.js`, so `auth.user` is reliably set.

## Changes

- `webapp/src/views/LoginView.vue`: Import `onMounted` and `auth`, add redirect logic on mount