### PR TITLE
fix: allow CLI client page access without authentication

### DIFF
--- a/webapp/ARCHITECTURE.md
+++ b/webapp/ARCHITECTURE.md
@@ -41,6 +41,7 @@ Admin link (upload-level): `/#/?id=<uploadId>&uploadToken=<token>`
 
 When `config.feature_authentication` is `"forced"`, a `router.beforeEach` guard redirects unauthenticated users to `/#/login`. Exceptions:
 - The login page itself (`to.name === 'login'`)
+- CLI client downloads (`to.name === 'clients'`) — so users can get the CLI without logging in
 - Download pages (`to.name === 'root' && to.query.id`) — so shared links still work
 
 ---

--- a/webapp/src/router.js
+++ b/webapp/src/router.js
@@ -57,6 +57,8 @@ router.beforeEach((to) => {
     if (config.feature_authentication !== 'forced') return true
     if (auth.user) return true
     if (to.name === 'login') return true
+    // Allow CLI client download page without authentication
+    if (to.name === 'clients') return true
     // Allow download pages — they have ?id= query
     if (to.name === 'root' && to.query.id) return true
     return { name: 'login' }


### PR DESCRIPTION
Fixes #569

## Problem

When `feature_authentication` is `"forced"`, the Vue router's `beforeEach` guard redirects unauthenticated users to `/#/login`. The `/#/clients` page (CLI client downloads) was not exempted, making it inaccessible without logging in first.

## Fix

Added `to.name === 'clients'` to the auth guard's exception list in `router.js`.

The server-side routes (`GET /version` and `/clients/` static file server) already use `stdChain` with no authentication required, so this change aligns the frontend with the backend behavior.

## Changes

- **`webapp/src/router.js`** — exempt `clients` route from forced-auth redirect
- **`webapp/ARCHITECTURE.md`** — document the new exception