### PR TITLE
webapp: add Documentation link and remove Upload button from top bar

### DIFF
--- a/webapp/src/components/AppHeader.vue
+++ b/webapp/src/components/AppHeader.vue
@@ -35,7 +35,7 @@ watch(() => route.fullPath, () => { mobileOpen.value = false })
         <router-link to="/" class="btn-ghost text-sm">
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                  d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+                  d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
           </svg>
           Upload
         </router-link>
@@ -49,6 +49,18 @@ watch(() => route.fullPath, () => { mobileOpen.value = false })
           </svg>
           CLI Client
         </router-link>
+
+        <a v-if="isFeatureEnabled('github')"
+           href="https://root-gg.github.io/plik/"
+           target="_blank"
+           rel="noopener noreferrer"
+           class="btn-ghost text-sm">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+          </svg>
+          Documentation
+        </a>
 
         <a v-if="isFeatureEnabled('github')"
            href="https://github.com/root-gg/plik"
@@ -119,7 +131,7 @@ watch(() => route.fullPath, () => { mobileOpen.value = false })
                             hover:bg-surface-700/50 hover:text-white transition-colors">
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                  d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
+                  d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
           </svg>
           Upload
         </router-link>
@@ -134,6 +146,19 @@ watch(() => route.fullPath, () => { mobileOpen.value = false })
           </svg>
           CLI Client
         </router-link>
+
+        <a v-if="isFeatureEnabled('github')"
+           href="https://root-gg.github.io/plik/"
+           target="_blank"
+           rel="noopener noreferrer"
+           class="flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm text-surface-200
+                  hover:bg-surface-700/50 hover:text-white transition-colors">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
+          </svg>
+          Documentation
+        </a>
 
         <a v-if="isFeatureEnabled('github')"
            href="https://github.com/root-gg/plik"


### PR DESCRIPTION
## Changes

### Documentation link
- Adds a **Documentation** link to the top bar pointing to https://root-gg.github.io/plik/
- Positioned between **CLI Client** and **Source**
- Uses a book icon (open book SVG) to distinguish it from the GitHub source link
- Only visible when `FeatureGithub` is enabled (same condition as the Source link)
- Added to both desktop and mobile navigation menus

### Upload button removed
- Removes the redundant **Upload** button from the nav bar
- The logo already links to `/` (the upload page), so users can still navigate there easily

## Screenshots
N/A — visual change only, straightforward nav link additions.
