### PR TITLE
Fix documentation search bar and menu scroll on mobile

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -2,10 +2,12 @@
 .VPNavBarSearch {
     display: flex !important;
     justify-content: center !important;
+    padding: 0 1rem !important;
 }
 
-.VPNavBarSearch .DocSearch-Button {
+.VPNavBarSearch .DocSearch-Button,
+.VPNavBarSearch .VPNavBarSearchButton {
     margin: 0 !important;
-    width: 700px !important;
+    width: 100% !important;
     max-width: 700px !important;
 }

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -49,12 +49,37 @@ make test-backends
 
 ### Running Locally
 
+Start the Go backend:
+
 ```bash
 cd server
 ./plikd --config ./plikd.cfg
 ```
 
 The server starts at [http://127.0.0.1:8080](http://127.0.0.1:8080) and serves both the API and the web interface.
+
+#### Webapp dev server
+
+For frontend development with hot-reload, run the Vite dev server which proxies API calls to the Go backend:
+
+```bash
+make docs
+cd webapp
+npm install
+npm run dev           # http://localhost:5173
+npm run dev -- --host # expose to local network
+```
+
+#### Documentation dev server
+
+To preview the documentation site locally:
+
+```bash
+cd docs
+npm install
+npm run dev           # http://localhost:5173/plik/
+npm run dev -- --host # expose to local network
+```
 
 ## Code Organization
 


### PR DESCRIPTION
## Summary

Fix the documentation site's search bar overflow on mobile and add dev server instructions to the contributing guide.

Fixes #564

## Changes

### `docs/.vitepress/theme/custom.css`
- Replace fixed `width: 700px` with `width: 100%; max-width: 700px` — the search bar now fills available space up to 700px and naturally shrinks on mobile screens
- Add `padding: 0 1rem` to prevent the search bar from touching screen edges
- Add `.VPNavBarSearchButton` selector alongside `.DocSearch-Button` to target the local search provider

### `docs/contributing.md`
- Add webapp dev server instructions (`npm run dev` with Vite proxy)
- Add documentation dev server instructions
- Document the `-- --host` flag for exposing to local network

## Before / After

**Before**: Search bar hardcoded to 700px causes horizontal overflow on mobile, breaking the layout and preventing proper sidebar scrolling.

**After**: Search bar uses responsive width, no horizontal overflow, sidebar scrolls correctly.