### PR TITLE
webapp: download view UX improvements, filename validation, and error handling

### DIFF
--- a/webapp/ARCHITECTURE.md
+++ b/webapp/ARCHITECTURE.md
@@ -152,6 +152,17 @@ try { return JSON.parse(text) } catch { return text }
 
 Errors from `fetchUpload` are displayed inline (not redirecting). This shows the actual server message like `"upload feafea not found"` instead of a generic error.
 
+### Separated error states in DownloadView
+
+DownloadView uses **two separate error refs** to avoid upload errors from hiding the upload content:
+
+| Ref | Purpose | Display |
+|-----|---------|---------|
+| `error` | Page-level failures (e.g., `fetchUpload` fails, upload not found) | Full-page error state via `v-else-if="error"` — replaces entire content |
+| `uploadError` | File transfer failures (e.g., 400 Bad Request during upload) | Dismissible inline banner within the upload content area |
+
+> **Why two refs**: The template uses `v-if="loading"` / `v-else-if="error"` / `v-else-if="upload"` branching. If file upload errors set `error`, the `v-else-if="error"` branch takes over and hides the sidebar + file list. The `uploadError` ref keeps errors in the `v-else-if="upload"` block so the user retains context.
+
 ---
 
 ## File Upload Mechanics
@@ -234,6 +245,21 @@ Files stored locally before upload use this shape (NOT the server shape):
 ```
 
 > **Gotcha**: Local files use `reference` as a key, not `id`. The `id` is only assigned by the server after upload. The `size` field is `size` locally but `fileSize` in server responses.
+
+---
+
+## Filename Length Limit
+
+Filenames are capped at **1024 characters** — enforced client-side at multiple points:
+
+| Location | Enforcement |
+|----------|-------------|
+| `UploadView.addFiles()` | Truncates `file.name` to 1024 chars when files are added to the staging list |
+| `FileRow.onNameInput()` | Truncates on blur (when editing finishes) |
+| `FileRow.onNameKeydown()` | Blocks character input at limit (allows Backspace/Delete/ctrl keys) |
+| `FileRow.onNamePaste()` | Intercepts paste, calculates available space, clamps inserted text |
+
+> **Note**: The server also validates filename length and returns a 400 if exceeded. The client-side enforcement prevents this from happening under normal use.
 
 ---
 
@@ -348,9 +374,9 @@ App.vue
 │   │   ├── UploadSidebar  — upload settings (one-shot, stream, TTL, etc.)
 │   │   ├── FileRow        — individual file display
 │   │   └── CodeEditor     — text paste mode with syntax highlighting
-│   └── DownloadView.vue   — file list, download links, admin actions
-│       ├── DownloadSidebar — upload info, admin URL, action buttons
-│       ├── FileRow         — download/QR/copy/remove per file + View button
+│   └── DownloadView.vue   — file list, admin actions
+│       ├── DownloadSidebar — upload info, share, admin URL, action buttons
+│       ├── FileRow         — file link (preview), caret (details), download/QR/copy/view/remove
 │       ├── CodeEditor      — inline file viewer (read-only)
 │       ├── QrCodeDialog    — QR code modal
 │       ├── CopyButton      — clipboard copy with feedback
@@ -596,4 +622,8 @@ For full details on the Docker multi-stage build and release packaging, see [rel
 10. **Vite dev server runs on port 5173/5174** — the Go backend runs on port 8080. During dev, Vite proxies API calls to the backend via `vite.config.js`.
 
 11. **`webapp/dist/` is gitignored** — never commit build artifacts. The CI/Docker build produces them fresh.
+
+12. **DownloadView has two error refs** — `error` (page-level) and `uploadError` (inline banner). Setting file upload errors on `error` hides the entire upload content due to template branching. Always use `uploadError` for file transfer failures.
+
+13. **Filenames are capped at 1024 characters** — enforced in `UploadView.addFiles()`, `FileRow.onNameInput/onNameKeydown/onNamePaste`. The server also validates this, so both layers must agree.
 

--- a/webapp/src/components/DownloadSidebar.vue
+++ b/webapp/src/components/DownloadSidebar.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue'
+import { ref, computed } from 'vue'
 import { formatDate } from '../utils.js'
 import { getArchiveURL, getAdminURL } from '../api.js'
 import CopyButton from './CopyButton.vue'
@@ -28,6 +28,31 @@ const adminUrl = computed(() => {
   if (!props.upload.admin || !props.upload.uploadToken) return null
   return getAdminURL(props.upload.id, props.upload.uploadToken)
 })
+
+// Share URL (download page without upload token)
+const shareUrl = computed(() => {
+  return `${window.location.origin}${window.location.pathname}#/?id=${props.upload.id}`
+})
+
+// Native share support (mobile + Chrome/Edge desktop)
+const canNativeShare = typeof navigator !== 'undefined' && !!navigator.share
+
+const shareSuccess = ref(false)
+let shareTimer = null
+
+async function nativeShare() {
+  try {
+    await navigator.share({ title: 'Plik Upload', url: shareUrl.value })
+    shareSuccess.value = true
+    clearTimeout(shareTimer)
+    shareTimer = setTimeout(() => { shareSuccess.value = false }, 2000)
+  } catch (err) {
+    // User cancelled or share failed — ignore
+    if (err.name !== 'AbortError') {
+      console.warn('Share failed', err)
+    }
+  }
+}
 
 // Admins can delete upload, or if upload is marked as removable
 const canDeleteUpload = computed(() => props.upload.admin || props.upload.removable)
@@ -69,6 +94,28 @@ const canAddFiles = computed(() => props.upload.admin && !props.upload.stream)
               class="text-xs px-2 py-0.5 rounded-full bg-surface-600/50 text-surface-300">
           🔒 Password
         </span>
+      </div>
+    </div>
+
+    <!-- Share -->
+    <div class="sidebar-section">
+      <h3 class="text-xs font-semibold text-surface-400 uppercase tracking-wider mb-2">Share</h3>
+      <button v-if="canNativeShare"
+              class="btn-primary w-full"
+              :class="shareSuccess ? 'bg-success-500/20 text-success-500' : ''"
+              @click="nativeShare">
+        <svg v-if="shareSuccess" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+        </svg>
+        <svg v-else class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z" />
+        </svg>
+        {{ shareSuccess ? 'Shared!' : 'Share' }}
+      </button>
+      <div v-else class="flex items-center gap-2 p-2 rounded bg-surface-800/50 min-w-0 overflow-hidden">
+        <span class="text-xs text-surface-300 truncate flex-1">{{ shareUrl }}</span>
+        <CopyButton :text="shareUrl" size="sm" />
       </div>
     </div>
 

--- a/webapp/src/components/FileRow.vue
+++ b/webapp/src/components/FileRow.vue
@@ -21,7 +21,48 @@ const isTextFile = computed(() => {
 const showDetails = ref(false)
 
 function onNameInput(e) {
-  emit('update-name', e.target.textContent.trim())
+  let name = e.target.textContent.trim()
+  if (name.length > 1024) {
+    name = name.slice(0, 1024)
+    e.target.textContent = name
+  }
+  emit('update-name', name)
+}
+
+function onNameKeydown(e) {
+  // Allow control keys, but block character input if at limit
+  if (e.target.textContent.length >= 1024 && !e.ctrlKey && !e.metaKey &&
+      e.key.length === 1 && !['Backspace', 'Delete'].includes(e.key)) {
+    e.preventDefault()
+  }
+}
+
+function onNamePaste(e) {
+  e.stopPropagation()
+  // Handle paste manually to enforce limit
+  e.preventDefault()
+  const text = e.clipboardData?.getData('text/plain') || ''
+  const el = e.target
+  const current = el.textContent || ''
+  const sel = window.getSelection()
+  const range = sel.rangeCount ? sel.getRangeAt(0) : null
+
+  // Calculate how many chars we can insert
+  let selectedLen = 0
+  if (range && el.contains(range.startContainer)) {
+    selectedLen = range.toString().length
+  }
+  const available = 1024 - current.length + selectedLen
+  if (available <= 0) return
+
+  const insert = text.replace(/\n/g, '').slice(0, available)
+  if (range) {
+    range.deleteContents()
+    range.insertNode(document.createTextNode(insert))
+    range.collapse(false)
+    sel.removeAllRanges()
+    sel.addRange(range)
+  }
 }
 
 function fileUrl() {
@@ -44,28 +85,46 @@ function fileUrl() {
       <!-- File name -->
       <div class="flex-1 min-w-0">
         <!-- Editable name (upload mode) -->
-        <div v-if="mode === 'upload'"
-             class="text-sm text-surface-100 truncate cursor-text outline-none
-                    hover:text-white focus:ring-1 focus:ring-accent-500/50 rounded px-1 -mx-1"
-             contenteditable="true"
-             @blur="onNameInput"
-             @keydown.enter.prevent="$event.target.blur()">
-          {{ file.fileName }}
+        <div v-if="mode === 'upload'" class="inline-flex items-center gap-1 min-w-0 w-full">
+          <div class="text-sm text-surface-100 cursor-text outline-none
+                      overflow-hidden text-ellipsis whitespace-nowrap
+                      focus:overflow-x-auto focus:text-clip focus:whitespace-normal
+                      hover:text-white focus:ring-1 focus:ring-accent-500/50 rounded px-1 -mx-1"
+               contenteditable="true"
+               @blur="onNameInput"
+               @keydown="onNameKeydown"
+               @keydown.enter.prevent="$event.target.blur()"
+               @paste="onNamePaste">
+            {{ file.fileName }}
+          </div>
+          <svg class="w-3 h-3 text-surface-500 shrink-0"
+               fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                  d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
+          </svg>
         </div>
 
-        <!-- Clickable name → toggle details (download mode) -->
-        <button v-else-if="mode === 'download'"
-                class="text-sm text-surface-100 truncate hover:text-accent-400 transition-colors text-left w-full"
-                @click="showDetails = !showDetails">
-          <span class="inline-flex items-center gap-1">
-            <svg class="w-3 h-3 text-surface-500 transition-transform duration-200"
+        <!-- Download mode: caret toggles details, name is a link -->
+        <div v-else-if="mode === 'download'" class="inline-flex items-center gap-1 min-w-0 w-full">
+          <button class="shrink-0 p-0.5 text-surface-500 hover:text-surface-300 transition-colors"
+                  title="Toggle details"
+                  @click="showDetails = !showDetails">
+            <svg class="w-3 h-3 transition-transform duration-200"
                  :class="showDetails ? 'rotate-90' : ''"
                  fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
             </svg>
+          </button>
+          <a v-if="file.status === 'uploaded'"
+             :href="fileUrl()"
+             class="text-sm text-surface-100 hover:text-accent-400 transition-colors truncate"
+             target="_blank">
+            {{ file.fileName }}
+          </a>
+          <span v-else class="text-sm text-surface-100 truncate">
             {{ file.fileName }}
           </span>
-        </button>
+        </div>
 
         <!-- Static name -->
         <div v-else class="text-sm text-surface-100 truncate">

--- a/webapp/src/views/DownloadView.vue
+++ b/webapp/src/views/DownloadView.vue
@@ -23,6 +23,7 @@ const router = useRouter()
 const upload = ref(null)
 const loading = ref(true)
 const error = ref(null)
+const uploadError = ref(null)
 const fileInput = ref(null)
 
 // Staged files pending upload
@@ -242,7 +243,7 @@ async function uploadPendingFiles() {
       }
       fileEntry.status = 'error'
       fileEntry.error = err.message || 'Upload failed'
-      error.value = err.message || `Failed to upload ${fileEntry.fileName}`
+      uploadError.value = err.message || `Failed to upload ${fileEntry.fileName}`
     }
   }
 
@@ -343,6 +344,20 @@ onMounted(async () => {
 
         <!-- Upload Content -->
         <template v-else-if="upload">
+          <!-- Inline Error Banner (for errors during file upload) -->
+          <div v-if="uploadError"
+               class="glass-card border-danger-500/50 p-4 flex items-center gap-3 animate-fade-in">
+            <svg class="w-5 h-5 text-danger-500 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                    d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <span class="text-sm text-danger-500">{{ uploadError }}</span>
+            <button class="ml-auto text-surface-400 hover:text-white" @click="uploadError = null">
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
           <!-- Comment -->
           <div v-if="upload.comments" class="glass-card p-4 animate-fade-in">
             <div class="flex items-center gap-2 mb-2">
@@ -395,6 +410,11 @@ onMounted(async () => {
               <h3 class="text-sm font-medium text-surface-400">
                 {{ activeFiles.length }} file{{ activeFiles.length > 1 ? 's' : '' }}
               </h3>
+              <CopyButton
+                v-if="fileLinks().length > 1"
+                :text="fileLinks().map(f => f.url).join('\n')"
+                label="Copy All Links"
+                size="sm" />
             </div>
 
             <FileRow v-for="file in activeFiles"
@@ -452,35 +472,7 @@ onMounted(async () => {
             <p class="text-surface-400">No files in this upload</p>
           </div>
 
-          <!-- Download Links Panel -->
-          <div v-if="fileLinks().length" class="glass-card p-4 space-y-3">
-            <div class="flex items-center justify-between">
-              <h3 class="text-xs font-semibold text-surface-400 uppercase tracking-wider">
-                Download Links
-              </h3>
-              <CopyButton
-                :text="fileLinks().map(f => f.url).join('\n')"
-                label="Copy All"
-                size="sm" />
-            </div>
-            <div v-for="fl in fileLinks()" :key="fl.id"
-                 class="flex items-center gap-2 group">
-              <a :href="fl.url"
-                 class="text-sm text-accent-400 hover:text-accent-300 transition-colors truncate flex-1">
-                {{ fl.fileName }}
-              </a>
-              <!-- QR code button -->
-              <button class="btn bg-surface-700/50 text-surface-400 hover:text-white px-2 py-1 text-xs opacity-0 group-hover:opacity-100 transition-opacity"
-                      title="Show QR code"
-                      @click="openQrFile(fl)">
-                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                        d="M4 4h6v6H4zM14 4h6v6h-6zM4 14h6v6H4zM17 14v3h3M14 17h3v3" />
-                </svg>
-              </button>
-              <CopyButton :text="fl.url" size="sm" />
-            </div>
-          </div>
+
         </template>
       </div>
     </main>

--- a/webapp/src/views/UploadView.vue
+++ b/webapp/src/views/UploadView.vue
@@ -119,7 +119,7 @@ function addFiles(rawFiles) {
 
     files.value.push({
       reference: generateRef(),
-      fileName: file.name,
+      fileName: file.name.slice(0, 1024),
       size: file.size,
       file: file,
       status: 'toUpload',


### PR DESCRIPTION
## Summary

Download view UX improvements, filename validation, and error handling.

## Changes

### Download View UX
- **Copy All Links** button moved to top-right of file list header (only shown when 2+ files)
- **Download Links panel** removed — individual file links are now accessible directly from filenames
- **Filename is a link** (without `&dl=1`) — clicking the name opens the file in-browser (preview); the separate green Download button triggers `?dl=1` for forced download
- **Caret + details area** — the chevron (▶) toggles file details (type, MD5, created date); only the filename itself is a clickable link
- **Share section** added to sidebar between Upload Info and Admin URL:
  - On mobile/Chrome (where `navigator.share` is available): a native Share button that opens the OS share sheet
  - On desktop fallback: a URL display with copy button (same pattern as Admin URL, but without the upload token)

### Filename Validation (1024 char limit)
- **`FileRow.vue`**: Enforces limit via `onNameKeydown` (blocks input at limit), `onNamePaste` (clamps pasted text), and `onNameInput` (truncates on blur)
- **`UploadView.vue`**: Truncates `file.name` to 1024 chars when files are added to the staging list

### Inline Upload Error Banner
- **`DownloadView.vue`**: Separate `uploadError` ref for file transfer failures (e.g., 400 Bad Request). Displays as a dismissible red banner within the upload content area — keeps the sidebar and file list visible instead of replacing everything with a full-page error

### Documentation
- **`ARCHITECTURE.md`**: Documented filename limit enforcement, separated error state pattern (`error` vs `uploadError`), and two new common pitfalls

## Why two error refs?

The template uses `v-if="loading"` / `v-else-if="error"` / `v-else-if="upload"` branching. If file upload errors set `error`, the entire upload content disappears. The `uploadError` ref keeps errors inside the `v-else-if="upload"` block so users retain context.