### PR TITLE
webapp: fix CLI client download 404 (double clients/ prefix)

### DIFF
--- a/webapp/src/views/ClientsView.vue
+++ b/webapp/src/views/ClientsView.vue
@@ -36,7 +36,7 @@ const grouped = computed(() => {
 })
 
 function clientDownloadURL(client) {
-    return `/clients/${client.path}`
+    return `/${client.path}`
 }
 
 function osLabel(os) {


### PR DESCRIPTION
## Bug

CLI client downloads from the UI return **404** despite the binaries being present in the container/release.

The download URL was `/clients/clients/linux-amd64/plik` (double `clients/` prefix).

## Root Cause

`gen_build_info.sh` stores client paths as `clients/linux-amd64/plik` (from `find clients -name "plik*"`). The old AngularJS template used `{{client.path}}` directly as the href — this worked as a relative URL.

The Vue 3 rewrite in `ClientsView.vue` incorrectly prepended `/clients/`, producing `/clients/clients/linux-amd64/plik`.

## Fix

Use `/${client.path}` instead of `/clients/${client.path}` in `ClientsView.vue`, matching the original AngularJS behavior.

No changes to `gen_build_info.sh`.