### PR TITLE
feat: display file content directly if text and 1-file uploads

### DIFF
--- a/docs/features/web-ui.md
+++ b/docs/features/web-ui.md
@@ -29,3 +29,12 @@ docker run -p 8080:8080 \
   -v my_background.jpg:/home/plik/webapp/dist/img/background.jpg \
   rootgg/plik
 ```
+
+## Features
+
+### Inline File Viewer
+
+The web interface includes an inline file viewer for text files (code, logs, markdown, etc.). 
+- **Auto-display**: If an upload contains only one text file, the viewer is displayed by default.
+- **Syntax Highlighting**: Automatic detection of hundreds of languages.
+- **JSON Formatting**: Pretty-print and validation buttons for JSON files.

--- a/webapp/ARCHITECTURE.md
+++ b/webapp/ARCHITECTURE.md
@@ -545,6 +545,8 @@ Reusable CodeMirror 6 wrapper (`CodeEditor.vue`) used in two contexts:
 
 **JSON prettify / validate**: When the detected language is JSON, two action buttons appear in the editor header bar. **Validate** (`JSON.parse()` only) checks syntax and shows a brief green "Valid" flash on success or a dismissable red error banner on failure — it never changes the content. **Prettify** (`JSON.parse()` → `JSON.stringify(…, null, 2)`) validates *and* reformats the content with 2-space indentation. In read-only mode (DownloadView file viewer) prettify updates the displayed view only — it does not modify the file on the server.
 
+**Auto-display**: In `DownloadView.vue`, if an upload contains exactly one text file, the viewer panel opens automatically on mount (or when the file finishes uploading). A watcher on `activeFiles` triggers `viewFile()` for the first file if it's the only one and it's a text file.
+
 ### Text-File Detection
 
 The `isTextFile()` utility in `utils.js` determines if a file can be viewed in the code editor based on:

--- a/webapp/src/views/DownloadView.vue
+++ b/webapp/src/views/DownloadView.vue
@@ -1,8 +1,8 @@
 <script setup>
-import { ref, onMounted, computed, nextTick } from 'vue'
+import { ref, onMounted, computed, nextTick, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { getUpload, removeUpload, removeFile as apiRemoveFile, uploadFile, getFileURL } from '../api.js'
-import { generateRef } from '../utils.js'
+import { generateRef, isTextFile } from '../utils.js'
 import { getToken, setToken } from '../tokenStore.js'
 import { consumePendingFiles } from '../pendingUploadStore.js'
 import { marked } from 'marked'
@@ -49,6 +49,7 @@ const viewingFile = ref(null)
 const viewingContent = ref('')
 const viewingLoading = ref(false)
 const viewingError = ref(null)
+const lastAutoViewedId = ref(null)
 
 async function viewFile(file) {
   // If already viewing this file, close it
@@ -300,6 +301,20 @@ onMounted(async () => {
     uploadPendingFiles()
   }
 })
+
+// Auto-show view panel if there is exactly one text file
+watch(activeFiles, (files) => {
+  if (files.length === 1) {
+    const file = files[0]
+    if (file.status === 'uploaded' && isTextFile(file) && lastAutoViewedId.value !== file.id) {
+      lastAutoViewedId.value = file.id
+      viewFile(file)
+    }
+  } else if (files.length > 1) {
+    // If more files added, we might want to reset scroll but keep viewer if it was manually opened.
+    // However, the requirement is only for "if upload has only one file".
+  }
+}, { immediate: true })
 </script>
 
 <template>


### PR DESCRIPTION
# Auto-display file viewer for single text file uploads
## Summary
This PR improves the user experience by automatically opening the inline file viewer when an upload contains exactly one text file. This is especially useful for text pastes or single-file code sharing, providing immediate visibility of the content.
## Key Changes
### Webapp
- **[DownloadView.vue](cci:7://file:///home/mathieu/go/src/github.com/root-gg/plik/webapp/src/views/DownloadView.vue:0:0-0:0)**: 
    - Added a watcher on `activeFiles` to detect single-file uploads.
    - Automatically triggers [viewFile()](cci:1://file:///home/mathieu/go/src/github.com/root-gg/plik/webapp/src/views/DownloadView.vue:53:0-77:1) if the file is a text file and is successfully uploaded.
    - Implemented `lastAutoViewedId` to prevent the viewer from re-opening if the user manually closes it.
### Documentation
- **[webapp/ARCHITECTURE.md](cci:7://file:///home/mathieu/go/src/github.com/root-gg/plik/webapp/ARCHITECTURE.md:0:0-0:0)**: Documented the auto-display logic in the internal architecture guide.
- **[docs/features/web-ui.md](cci:7://file:///home/mathieu/go/src/github.com/root-gg/plik/docs/features/web-ui.md:0:0-0:0)**: Added a "Inline File Viewer" section to the user-facing documentation to highlight this feature.
## Verification
- Verified auto-display for single text file uploads (paste & file).
- Verified that multiple files or non-text files do not trigger the viewer.
- Verified that manual closing of the viewer is respected.
- Verified documentation build with `make docs`.