### PR TITLE
fix: prevent incorrect docker tagging in PR builds by allowing RELEAS…

### DIFF
--- a/.github/workflows/docker-build-pr.yaml
+++ b/.github/workflows/docker-build-pr.yaml
@@ -71,6 +71,7 @@ jobs:
       - name: Build and push
         env:
           TAG: pr-${{ github.event.issue.number }}
+          RELEASE: "false"
           PUSH_TO_DOCKER_HUB: "true"
         run: make release-and-push-to-docker-hub
 

--- a/releaser/ARCHITECTURE.md
+++ b/releaser/ARCHITECTURE.md
@@ -59,6 +59,7 @@ Runs on the **host machine**. Orchestrates the entire release from the project r
 | `CLIENT_TARGETS` | *(from build_clients.sh default)* | Override client cross-compilation targets |
 | `CC` | *(auto-detected)* | Override cross compiler |
 | `PUSH_TO_DOCKER_HUB` | *(unset)* | If set, push images to Docker Hub |
+| `RELEASE` | *(auto)* | Set to `false` to explicitly disable release tagging (e.g. in PR builds) |
 
 ### Dockerfile — Multi-Stage Build
 

--- a/releaser/release.sh
+++ b/releaser/release.sh
@@ -17,10 +17,12 @@ if ! make build-info | grep "mint=true" >/dev/null ; then
   git status
 fi
 
-if make build-info | grep "release=true" >/dev/null ; then
-  RELEASE=true
-else
-  echo "!!! Release is not tagged !!!"
+if [[ -z "$RELEASE" ]]; then
+  if make build-info | grep "release=true" >/dev/null ; then
+    RELEASE=true
+  else
+    echo "!!! Release is not tagged !!!"
+  fi
 fi
 
 DOCKER_IMAGE=${DOCKER_IMAGE:-rootgg/plik}


### PR DESCRIPTION
This PR fixes a bug in the `docker-build-pr` workflow where Docker images were being incorrectly tagged as release versions (e.g., `v1.0-RC1`) when the PR branch HEAD matched an existing git tag.
### Changes:
1.  **Modified [releaser/release.sh](cci:7://file:///home/mathieu/go/src/github.com/root-gg/plik/releaser/release.sh:0:0-0:0)**: It now respects an explicit `RELEASE=false` environment variable override. This prevents the auto-detection logic from incorrectly marking a build as a release.
2.  **Updated [docker-build-pr.yaml](cci:7://file:///home/mathieu/go/src/github.com/root-gg/plik/.github/workflows/docker-build-pr.yaml:0:0-0:0)**: The workflow now explicitly sets `RELEASE: "false"` in the environment to ensure that PR builds are never treated as official releases, regardless of the git state.
3.  **Updated Documentation**: Documented the new `RELEASE=false` override capability in [ARCHITECTURE.md](cci:7://file:///home/mathieu/go/src/github.com/root-gg/plik/ARCHITECTURE.md:0:0-0:0).
### Verification:
I verified the shell logic changes in [releaser/release.sh](cci:7://file:///home/mathieu/go/src/github.com/root-gg/plik/releaser/release.sh:0:0-0:0) by simulating an execution with `RELEASE=false`. The simulation confirmed that:
- The `RELEASE` variable is preserved.
- The `EXTRA_ARGS` for Docker build only include the PR-specific tag and **not** the version tag.
- The image is NOT tagged as `latest`.