### PR TITLE
Fix pre-existing lint warnings

### DIFF
--- a/server/handlers/get_file_test.go
+++ b/server/handlers/get_file_test.go
@@ -47,7 +47,6 @@ func TestGetFile(t *testing.T) {
 
 	req, err := http.NewRequest("GET", "/file/"+upload.ID+"/"+file.ID+"/"+file.Name+"?dl=true", bytes.NewBuffer([]byte{}))
 	require.NoError(t, err, "unable to create new request")
-	req.URL.Query().Set("dl", "true")
 
 	rr := ctx.NewRecorder(req)
 	GetFile(ctx, rr, req)

--- a/server/handlers/ovh.go
+++ b/server/handlers/ovh.go
@@ -41,7 +41,7 @@ func decodeOVHResponse(resp *http.Response) ([]byte, error) {
 
 	if resp.StatusCode > 399 {
 		// Decode OVH error information from response
-		if body != nil && len(body) > 0 {
+		if len(body) > 0 {
 			var ovhErr ovhError
 			err := json.Unmarshal(body, &ovhErr)
 			if err == nil {


### PR DESCRIPTION
Fix two pre-existing lint warnings flagged by `gopls` / `staticcheck`:

### Changes

- **`server/handlers/ovh.go:44`** — Remove redundant `nil` check before `len()` (`staticcheck` S1009). `len()` on a nil slice is defined as zero in Go, so `if body != nil && len(body) > 0` is simplified to `if len(body) > 0`.

- **`server/handlers/get_file_test.go:50`** — Remove no-op `req.URL.Query().Set("dl", "true")` (SA4027). `(*net/url.URL).Query()` returns a copy — calling `.Set()` on that copy has no effect on the URL. The `?dl=true` parameter is already set in the URL string literal.

Closes #588