### PR TITLE
docs: document metadata import/export

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -67,6 +67,7 @@ export default withMermaid(defineConfig({
                     items: [
                         { text: 'Reverse Proxy', link: '/operations/reverse-proxy' },
                         { text: 'Cross Compilation', link: '/operations/cross-compilation' },
+                        { text: 'Import / Export', link: '/operations/import-export' },
                     ],
                 },
                 {

--- a/docs/backends/metadata.md
+++ b/docs/backends/metadata.md
@@ -59,3 +59,7 @@ Enable slow query detection:
 ## Schema Migrations
 
 Plik uses [gormigrate](https://github.com/go-gormigrate/gormigrate) for automatic schema migrations. The database schema is created or updated automatically on server start.
+
+## Migrating Between Backends
+
+To migrate data between different metadata backends (e.g. SQLite → PostgreSQL), use the `plikd export` and `plikd import` commands. See the [Import / Export](/operations/import-export) guide for details.

--- a/docs/operations/import-export.md
+++ b/docs/operations/import-export.md
@@ -1,0 +1,66 @@
+# Import / Export
+
+Plik can export and import all metadata (users, tokens, uploads, files, settings) using the `plikd` CLI. This is useful for **backend migrations** (e.g. SQLite → PostgreSQL), **backups**, and **disaster recovery**.
+
+::: warning
+Import/export handles **metadata only** — file data stored in the data backend (filesystem, S3, etc.) is not included. You must separately back up or migrate the data backend contents.
+:::
+
+## Export
+
+Dump all metadata to a file:
+
+```bash
+plikd export /path/to/export.bin
+```
+
+Sample output:
+
+```
+Exporting metadata from sqlite3 plik.db to /path/to/export.bin
+exported 3 users
+exported 5 tokens
+exported 142 uploads
+exported 287 files
+exported 1 settings
+```
+
+The export includes soft-deleted uploads to preserve foreign key integrity. CLI auth sessions are **not exported** — they are ephemeral and have no value outside the running server.
+
+## Import
+
+Load metadata from a previously exported file:
+
+```bash
+plikd import /path/to/export.bin
+```
+
+Sample output:
+
+```
+Importing metadata from /path/to/export.bin to postgres host=localhost...
+imported 3 out of 3 uploads
+imported 287 out of 287 files
+imported 3 out of 3 users
+imported 5 out of 5 tokens
+imported 1 out of 1 settings
+```
+
+### `--ignore-errors`
+
+By default, import stops on the first error (e.g. a duplicate key). Use `--ignore-errors` to skip problematic records and continue:
+
+```bash
+plikd import --ignore-errors /path/to/export.bin
+```
+
+Failed records are logged to stdout with details.
+
+## File Format
+
+The export file uses Go's [gob](https://pkg.go.dev/encoding/gob) encoding compressed with [Snappy](https://github.com/golang/snappy). This format is:
+
+- **Architecture-independent** — portable across `amd64`, `arm64`, etc.
+- **Compact** — binary encoding + compression keeps files small
+- **Streaming** — objects are written sequentially, so memory usage stays constant regardless of database size
+- **Go-specific** — the file cannot be read by non-Go tools

--- a/server/ARCHITECTURE.md
+++ b/server/ARCHITECTURE.md
@@ -33,8 +33,8 @@ The server binary `plikd` uses [cobra](https://github.com/spf13/cobra) for CLI m
 | `token.go` | `plikd token create/list/delete` | Manage user tokens |
 | `file.go` | `plikd file list/delete` | Manage uploads/files |
 | `clean.go` | `plikd clean` | Run metadata cleanup |
-| `import.go` | `plikd import` | Import metadata from JSON |
-| `export.go` | `plikd export` | Export metadata to JSON |
+| `import.go` | `plikd import` | Import metadata from gob + Snappy binary |
+| `export.go` | `plikd export` | Export metadata to gob + Snappy binary |
 
 Config loading order: `--config` flag → `PLIKD_CONFIG` env → `./plikd.cfg` → `/etc/plikd.cfg`.
 
@@ -141,8 +141,19 @@ Uses GORM with gormigrate for schema management across SQLite3, PostgreSQL, and 
 | `cli_auth_session.go` | CLI auth session CRUD (create, get by code, update, delete expired) |
 | `setting.go` | Server settings key/value store |
 | `stats.go` | Aggregate statistics queries |
-| `exporter.go` | JSON export of all data |
-| `importer.go` | JSON import |
+| `exporter.go` | gob + Snappy export of all metadata |
+| `importer.go` | gob + Snappy import |
+
+### Import / Export
+
+The `plikd export` and `plikd import` commands dump and restore all metadata (users, tokens, uploads, files, settings) to/from a single binary file.
+
+- **Format**: Go [gob](https://pkg.go.dev/encoding/gob) encoding compressed with [Snappy](https://github.com/golang/snappy). Architecture-independent (portable across `amd64`/`arm64`), streaming (constant memory), Go-specific (not human-readable).
+- **Export order**: users → tokens → uploads (including soft-deleted) → files → settings. CLI auth sessions are intentionally excluded (ephemeral).
+- **Import**: decodes sequentially, calls `Create*` on the metadata backend. Supports `--ignore-errors` to skip problematic records.
+- **Use cases**: backend migration (e.g. SQLite → PostgreSQL), backups, disaster recovery.
+
+> **Note**: Only metadata is exported — file data in the data backend must be migrated separately.
 
 ### Migration Dump Tests
 


### PR DESCRIPTION
Closes #583

Add documentation for the `plikd export` / `plikd import` CLI commands.

### Changes

- **New page** `docs/operations/import-export.md` — covers export/import usage, `--ignore-errors` flag, gob+Snappy format rationale, and notes on CLIAuthSession exclusion
- **Sidebar** — added "Import / Export" entry under Operations
- **Metadata backends** — added "Migrating Between Backends" cross-reference
- **Server ARCHITECTURE.md** — fixed 4× inaccurate "JSON" labels → "gob + Snappy", added Import/Export subsection