### PR TITLE
feat: add :preview Docker tag for all releases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Plik is a temporary file upload system (WeTransfer-like) written in Go, with a V
 | Config    | TOML (server), TOML (client `.plikrc`) |
 | Data      | File, OpenStack Swift, S3, Google Cloud Storage |
 | Metadata  | SQLite3, PostgreSQL, MySQL (via GORM) |
-| CI        | GitHub Actions (tests, docker build/deploy on PR comment) |
+| CI        | GitHub Actions (tests, docker build/deploy on PR comment, release: `dev`/`preview`/`latest`/`{version}`) |
 
 ## Repo Layout
 

--- a/docs/guide/docker.md
+++ b/docs/guide/docker.md
@@ -10,7 +10,8 @@ docker run -p 8080:8080 rootgg/plik
 
 Available tags:
 - `latest` — Latest stable release
-- `__VERSION__` — Specific version
+- `preview` — Latest release (including pre-releases like `-RC`)
+- `__VERSION__` — Specific version (e.g. `1.4.0`, `1.4-RC1`)
 - `dev` — Latest build from master branch
 
 ## Custom Configuration

--- a/releaser/ARCHITECTURE.md
+++ b/releaser/ARCHITECTURE.md
@@ -47,6 +47,7 @@ Runs on the **host machine**. Orchestrates the entire release from the project r
 7. **Docker push** (optional): If `PUSH_TO_DOCKER_HUB` is set, builds the final Docker image stage and pushes with tags:
    - `rootgg/plik:dev` (always)
    - `rootgg/plik:{version}` (only if `release=true`)
+   - `rootgg/plik:preview` (only if `release=true` — tracks the latest release including pre-releases)
    - `rootgg/plik:latest` (only if `release=true` **and** version contains no `-` suffix, e.g. `-RC1`, `-alpha`, `-test` all prevent tagging as latest)
 
 #### Environment Variables
@@ -160,7 +161,7 @@ This script generates build metadata consumed by the server at startup and expos
 ```
 
 Key fields:
-- **`isRelease`**: `true` if HEAD commit matches the version tag — controls whether Docker Hub gets `:{version}` tag (and `:latest` for stable releases, i.e. versions without a `-` suffix)
+- **`isRelease`**: `true` if HEAD commit matches the version tag — controls whether Docker Hub gets `:{version}` + `:preview` tags (and `:latest` for stable releases, i.e. versions without a `-` suffix)
 - **`isMint`**: `true` if the working tree is clean (no uncommitted changes) — release.sh warns if dirty
 - **`clients`**: Enumerated from `clients/` directory, used by the web UI to display download links
 - **`releases`**: Built from `changelog/` directory entries matched against git tags

--- a/releaser/release.sh
+++ b/releaser/release.sh
@@ -42,6 +42,7 @@ if [[ -n "$PUSH_TO_DOCKER_HUB" ]]; then
   EXTRA_ARGS="-t $DOCKER_IMAGE:$DOCKER_TAG"
   if [[ "$RELEASE" == "true" ]]; then
     EXTRA_ARGS="$EXTRA_ARGS -t $DOCKER_IMAGE:$VERSION"
+    EXTRA_ARGS="$EXTRA_ARGS -t $DOCKER_IMAGE:preview"
     # Only tag as latest for stable releases (no suffix like -RC1, -alpha, -test, etc.)
     if [[ ! "$VERSION" =~ - ]]; then
       EXTRA_ARGS="$EXTRA_ARGS -t $DOCKER_IMAGE:latest"


### PR DESCRIPTION
## Summary

Add a `:preview` Docker tag that tracks the latest release (stable or pre-release).

Follow-up to #563.

## Docker Tag Scheme

| Tag | Meaning | When pushed |
|-----|---------|-------------|
| `dev` | Latest commit on master | Every push to `master` |
| `preview` | Latest release (including pre-releases like `-RC`) | Release workflow |
| `latest` | Latest **stable** release | Release workflow (stable only) |
| `{version}` | Specific version (e.g. `1.4.0`, `1.4-RC1`) | Release workflow |

## Changes

- `releaser/release.sh` — one line: tag `:preview` for all releases
- `docs/guide/docker.md` — added `preview` to user-facing tag list
- `releaser/ARCHITECTURE.md` + `docs/architecture/releaser.md` — updated docs
- `AGENTS.md` — updated CI row