### PR TITLE
chore: add go fix to lint target and apply go fix across codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,8 @@ cd server && ./plikd        # Run server on http://127.0.0.1:8080
 make test                   # Unit tests + CLI integration tests
 make test-backends           # Docker-based backend integration tests (all)
 make test-backend mariadb    # Docker-based test for a single backend
-make lint                   # go fmt + go vet
+make lint                   # go fmt + go vet + go fix
+make gofix                  # Run go fix
 make vuln                   # govulncheck (report only)
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,8 @@ lint:
 	if [[ -z "$$OUT" ]]; then echo " OK" ; else echo " FAIL"; echo "$$OUT"; FAIL=1 ; fi ;\
 	echo -n " - go vet :" ; OUT=`go vet ./... 2>&1` ; \
 	if [[ -z "$$OUT" ]]; then echo " OK" ; else echo " FAIL"; echo "$$OUT"; FAIL=1 ; fi ;\
+	echo -n " - go fix :" ; OUT=`go fix ./... 2>&1` ; \
+	if [[ -z "$$OUT" ]]; then echo " OK" ; else echo " FAIL"; echo "$$OUT"; FAIL=1 ; fi ;\
 	test $$FAIL -eq 0
 
 ###
@@ -92,6 +94,12 @@ vuln:
 ###
 fmt:
 	@gofmt -w -s client server plik
+
+###
+# Run go fix
+###
+gofix:
+	@go fix -v ./...
 
 ###
 # Run tests

--- a/client/archive/archive.go
+++ b/client/archive/archive.go
@@ -11,16 +11,16 @@ import (
 // Backend interface describe methods that the different
 // types of archive backend must implement to work.
 type Backend interface {
-	Configure(arguments map[string]interface{}) (err error)
+	Configure(arguments map[string]any) (err error)
 	Archive(files []string) (reader io.Reader, err error)
 	Comments() (comments string)
 	GetFileName(files []string) (name string)
-	GetConfiguration() interface{}
+	GetConfiguration() any
 }
 
 // NewArchiveBackend instantiate the wanted archive backend with the name provided in configuration file
 // We are passing its configuration found in .plikrc file or arguments
-func NewArchiveBackend(name string, config map[string]interface{}) (backend Backend, err error) {
+func NewArchiveBackend(name string, config map[string]any) (backend Backend, err error) {
 	switch name {
 	case "tar":
 		backend, err = tar.NewTarBackend(config)

--- a/client/archive/tar/config.go
+++ b/client/archive/tar/config.go
@@ -13,7 +13,7 @@ type BackendConfig struct {
 
 // NewTarBackendConfig instantiate a new Backend Configuration
 // from config map passed as argument
-func NewTarBackendConfig(config map[string]interface{}) (tb *BackendConfig) {
+func NewTarBackendConfig(config map[string]any) (tb *BackendConfig) {
 	tb = new(BackendConfig)
 	tb.Tar = "/bin/tar"
 	tb.Compress = "gzip"

--- a/client/archive/tar/tar.go
+++ b/client/archive/tar/tar.go
@@ -17,7 +17,7 @@ type Backend struct {
 
 // NewTarBackend instantiate a new Tar Archive Backend
 // and configure it from config map
-func NewTarBackend(config map[string]interface{}) (tb *Backend, err error) {
+func NewTarBackend(config map[string]any) (tb *Backend, err error) {
 	tb = new(Backend)
 	tb.Config = NewTarBackendConfig(config)
 	if _, err = os.Stat(tb.Config.Tar); os.IsNotExist(err) || os.IsPermission(err) {
@@ -29,7 +29,7 @@ func NewTarBackend(config map[string]interface{}) (tb *Backend, err error) {
 }
 
 // Configure implementation for TAR Archive Backend
-func (tb *Backend) Configure(arguments map[string]interface{}) (err error) {
+func (tb *Backend) Configure(arguments map[string]any) (err error) {
 	if arguments["--compress"] != nil && arguments["--compress"].(string) != "" {
 		tb.Config.Compress = arguments["--compress"].(string)
 	}
@@ -96,7 +96,7 @@ func (tb *Backend) Comments() string {
 }
 
 // GetConfiguration implementation for TAR Archive Backend
-func (tb *Backend) GetConfiguration() interface{} {
+func (tb *Backend) GetConfiguration() any {
 	return tb.Config
 }
 

--- a/client/archive/zip/config.go
+++ b/client/archive/zip/config.go
@@ -12,7 +12,7 @@ type BackendConfig struct {
 
 // NewZipBackendConfig instantiate a new Backend Configuration
 // from config map passed as argument
-func NewZipBackendConfig(config map[string]interface{}) (zb *BackendConfig) {
+func NewZipBackendConfig(config map[string]any) (zb *BackendConfig) {
 	zb = new(BackendConfig)
 	zb.Zip = "/bin/zip"
 	utils.Assign(zb, config)

--- a/client/archive/zip/zip.go
+++ b/client/archive/zip/zip.go
@@ -17,7 +17,7 @@ type Backend struct {
 
 // NewZipBackend instantiate a new ZIP Archive Backend
 // and configure it from config map
-func NewZipBackend(config map[string]interface{}) (zb *Backend, err error) {
+func NewZipBackend(config map[string]any) (zb *Backend, err error) {
 	zb = new(Backend)
 	zb.Config = NewZipBackendConfig(config)
 	if _, err = os.Stat(zb.Config.Zip); os.IsNotExist(err) || os.IsPermission(err) {
@@ -29,7 +29,7 @@ func NewZipBackend(config map[string]interface{}) (zb *Backend, err error) {
 }
 
 // Configure implementation for ZIP Archive Backend
-func (zb *Backend) Configure(arguments map[string]interface{}) (err error) {
+func (zb *Backend) Configure(arguments map[string]any) (err error) {
 	if arguments["--archive-options"] != nil && arguments["--archive-options"].(string) != "" {
 		zb.Config.Options = arguments["--archive-options"].(string)
 	}
@@ -94,6 +94,6 @@ func (zb *Backend) GetFileName(files []string) (name string) {
 }
 
 // GetConfiguration implementation for ZIP Archive Backend
-func (zb *Backend) GetConfiguration() interface{} {
+func (zb *Backend) GetConfiguration() any {
 	return zb.Config
 }

--- a/client/config.go
+++ b/client/config.go
@@ -26,10 +26,10 @@ type CliConfig struct {
 	Stream         bool
 	Secure         bool
 	SecureMethod   string
-	SecureOptions  map[string]interface{}
+	SecureOptions  map[string]any
 	Archive        bool
 	ArchiveMethod  string
-	ArchiveOptions map[string]interface{}
+	ArchiveOptions map[string]any
 	DownloadBinary string
 	Comments       string
 	Login          string
@@ -50,12 +50,12 @@ func NewUploadConfig() (config *CliConfig) {
 	config = new(CliConfig)
 	config.URL = "http://127.0.0.1:8080"
 	config.ArchiveMethod = "tar"
-	config.ArchiveOptions = make(map[string]interface{})
+	config.ArchiveOptions = make(map[string]any)
 	config.ArchiveOptions["Tar"] = "/bin/tar"
 	config.ArchiveOptions["Compress"] = "gzip"
 	config.ArchiveOptions["Options"] = ""
 	config.SecureMethod = "openssl"
-	config.SecureOptions = make(map[string]interface{})
+	config.SecureOptions = make(map[string]any)
 	config.SecureOptions["Openssl"] = "/usr/bin/openssl"
 	config.SecureOptions["Cipher"] = "aes-256-cbc"
 	config.SecureOptions["Options"] = "-md sha512 -pbkdf2 -iter 120000"

--- a/client/crypto/crypto.go
+++ b/client/crypto/crypto.go
@@ -11,15 +11,15 @@ import (
 // Backend interface describe methods that the different
 // types of crypto backend must implement to work.
 type Backend interface {
-	Configure(arguments map[string]interface{}) (err error)
+	Configure(arguments map[string]any) (err error)
 	Encrypt(in io.Reader) (out io.Reader, err error)
 	Comments() string
-	GetConfiguration() interface{}
+	GetConfiguration() any
 }
 
 // NewCryptoBackend instantiate the wanted archive backend with the name provided in configuration file
 // We are passing its configuration found in .plikrc file or arguments
-func NewCryptoBackend(name string, config map[string]interface{}) (backend Backend, err error) {
+func NewCryptoBackend(name string, config map[string]any) (backend Backend, err error) {
 	switch name {
 	case "openssl":
 		backend = openssl.NewOpenSSLBackend(config)

--- a/client/crypto/openssl/config.go
+++ b/client/crypto/openssl/config.go
@@ -14,7 +14,7 @@ type Config struct {
 
 // NewOpenSSLBackendConfig instantiate a new Backend Configuration
 // from config map passed as argument
-func NewOpenSSLBackendConfig(params map[string]interface{}) (config *Config) {
+func NewOpenSSLBackendConfig(params map[string]any) (config *Config) {
 	config = new(Config)
 	config.Openssl = "/usr/bin/openssl"
 	config.Cipher = "aes-256-cbc"

--- a/client/crypto/openssl/openssl.go
+++ b/client/crypto/openssl/openssl.go
@@ -17,14 +17,14 @@ type Backend struct {
 
 // NewOpenSSLBackend instantiate a new PGP Crypto Backend
 // and configure it from config map
-func NewOpenSSLBackend(config map[string]interface{}) (ob *Backend) {
+func NewOpenSSLBackend(config map[string]any) (ob *Backend) {
 	ob = new(Backend)
 	ob.Config = NewOpenSSLBackendConfig(config)
 	return
 }
 
 // Configure implementation for OpenSSL Crypto Backend
-func (ob *Backend) Configure(arguments map[string]interface{}) (err error) {
+func (ob *Backend) Configure(arguments map[string]any) (err error) {
 	if arguments["--openssl"] != nil && arguments["--openssl"].(string) != "" {
 		ob.Config.Openssl = arguments["--openssl"].(string)
 	}
@@ -110,6 +110,6 @@ func (ob *Backend) Comments() string {
 }
 
 // GetConfiguration implementation for OpenSSL Crypto Backend
-func (ob *Backend) GetConfiguration() interface{} {
+func (ob *Backend) GetConfiguration() any {
 	return ob.Config
 }

--- a/client/crypto/pgp/config.go
+++ b/client/crypto/pgp/config.go
@@ -18,7 +18,7 @@ type Config struct {
 
 // NewPgpBackendConfig instantiate a new Backend Configuration
 // from config map passed as argument
-func NewPgpBackendConfig(params map[string]interface{}) (config *Config) {
+func NewPgpBackendConfig(params map[string]any) (config *Config) {
 	config = new(Config)
 	config.Gpg = "/usr/bin/gpg"
 	config.Keyring = os.Getenv("HOME") + "/.gnupg/pubring.gpg"

--- a/client/crypto/pgp/pgp.go
+++ b/client/crypto/pgp/pgp.go
@@ -18,14 +18,14 @@ type Backend struct {
 
 // NewPgpBackend instantiate a new PGP Crypto Backend
 // and configure it from config map
-func NewPgpBackend(config map[string]interface{}) (pb *Backend) {
+func NewPgpBackend(config map[string]any) (pb *Backend) {
 	pb = new(Backend)
 	pb.Config = NewPgpBackendConfig(config)
 	return
 }
 
 // Configure implementation for PGP Crypto Backend
-func (pb *Backend) Configure(arguments map[string]interface{}) (err error) {
+func (pb *Backend) Configure(arguments map[string]any) (err error) {
 
 	// Parse options
 	if arguments["--recipient"] != nil && arguments["--recipient"].(string) != "" {
@@ -81,12 +81,13 @@ func (pb *Backend) Configure(arguments map[string]interface{}) (err error) {
 		pb.Config.Entity = entitiesFound[intToEntity[0]]
 		pb.Config.Email = emailsFound[0]
 	} else {
-		errorMessage := fmt.Sprintf("There are %d keys that match your search :\n", countEntitiesFound)
+		var errorMessage strings.Builder
+		errorMessage.WriteString(fmt.Sprintf("There are %d keys that match your search :\n", countEntitiesFound))
 		for _, email := range emailsFound {
-			errorMessage += fmt.Sprintf("\t-%s\n", email)
+			errorMessage.WriteString(fmt.Sprintf("\t-%s\n", email))
 		}
 
-		return errors.New(errorMessage)
+		return errors.New(errorMessage.String())
 	}
 
 	return nil
@@ -132,6 +133,6 @@ func (pb *Backend) Comments() string {
 }
 
 // GetConfiguration implementation for PGP Crypto Backend
-func (pb *Backend) GetConfiguration() interface{} {
+func (pb *Backend) GetConfiguration() any {
 	return pb.Config
 }

--- a/client/plik.go
+++ b/client/plik.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Vars
-var arguments map[string]interface{}
+var arguments map[string]any
 var config *CliConfig
 var archiveBackend archive.Backend
 var cryptoBackend crypto.Backend
@@ -393,7 +393,7 @@ func getFileCommand(file *plik.File) (command string, err error) {
 	return
 }
 
-func printf(format string, args ...interface{}) {
+func printf(format string, args ...any) {
 	if !config.Quiet {
 		fmt.Printf(format, args...)
 	}

--- a/plik/setup_test.go
+++ b/plik/setup_test.go
@@ -59,7 +59,7 @@ func TestMain(m *testing.M) {
 		if os.Getenv("data_backend") != "" {
 			testConfig.DataBackend = os.Getenv("data_backend")
 			if os.Getenv("data_backend_config") != "" {
-				var dataBackendConfig = make(map[string]interface{})
+				var dataBackendConfig = make(map[string]any)
 				err = json.Unmarshal([]byte(os.Getenv("data_backend_config")), &dataBackendConfig)
 				if err != nil {
 					fmt.Printf("Unable to deserialize data_backend_config : %s\n", err)

--- a/plik/z1_e2e_test.go
+++ b/plik/z1_e2e_test.go
@@ -67,12 +67,10 @@ func TestDownloadDuringUpload(t *testing.T) {
 	require.Contains(t, err.Error(), fmt.Sprintf("file %s (%s) is not available : missing", file.Name, file.metadata.ID), "invalid error")
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		err = upload.Upload()
 		require.NoError(t, err, "unable to upload file")
-		wg.Done()
-	}()
+	})
 
 	time.Sleep(time.Second)
 
@@ -232,12 +230,10 @@ func TestStream(t *testing.T) {
 
 	errors := make(chan error, 1)
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		time.Sleep(50 * time.Millisecond)
 		errors <- upload.Upload()
-	}()
+	})
 
 	f := func() {
 		for {

--- a/server/common/authentication.go
+++ b/server/common/authentication.go
@@ -82,7 +82,7 @@ func (sa *SessionAuthenticator) GenAuthCookies(user *User) (sessionCookie *http.
 
 // ParseSessionCookie parse and validate the session cookie
 func (sa *SessionAuthenticator) ParseSessionCookie(value string) (uid string, xsrf string, err error) {
-	session, err := jwt.Parse(value, func(t *jwt.Token) (interface{}, error) {
+	session, err := jwt.Parse(value, func(t *jwt.Token) (any, error) {
 		// Verify signing algorithm
 		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected siging method : %v", t.Header["alg"])

--- a/server/common/cli_auth_session.go
+++ b/server/common/cli_auth_session.go
@@ -43,7 +43,7 @@ func (s *CLIAuthSession) IsExpired() bool {
 func generateCode() string {
 	const charset = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789" // No 0/O/1/I to avoid confusion
 	var b strings.Builder
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		if i == 4 {
 			b.WriteByte('-')
 		}

--- a/server/common/cli_auth_session_test.go
+++ b/server/common/cli_auth_session_test.go
@@ -41,7 +41,7 @@ func TestGenerateCode_Format(t *testing.T) {
 
 func TestGenerateCode_NoConfusingCharacters(t *testing.T) {
 	// Generate many codes and make sure none contain 0, O, 1, or I
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		code := generateCode()
 		require.NotContains(t, code, "0", "code should not contain 0")
 		require.NotContains(t, code, "O", "code should not contain O")

--- a/server/common/config.go
+++ b/server/common/config.go
@@ -105,10 +105,10 @@ type Configuration struct {
 	OIDCValidDomains         []string `json:"-"`
 	OIDCRequireVerifiedEmail bool     `json:"-"`
 
-	MetadataBackendConfig map[string]interface{} `json:"-"`
+	MetadataBackendConfig map[string]any `json:"-"`
 
-	DataBackend       string                 `json:"-"`
-	DataBackendConfig map[string]interface{} `json:"-"`
+	DataBackend       string         `json:"-"`
+	DataBackendConfig map[string]any `json:"-"`
 
 	downloadDomainURL      *url.URL
 	downloadDomainURLAlias []*url.URL

--- a/server/common/config_test.go
+++ b/server/common/config_test.go
@@ -288,7 +288,7 @@ func TestConfiguration_EnvironmentOverride(t *testing.T) {
 	require.Equal(t, "1.2.3.4", config.ListenAddress)
 	require.Equal(t, int64(42), config.MaxFileSize)
 	require.EqualValues(t, []string{"127.0.0.1"}, config.UploadWhitelist)
-	require.EqualValues(t, map[string]interface{}{"path": "files"}, config.MetadataBackendConfig)
+	require.EqualValues(t, map[string]any{"path": "files"}, config.MetadataBackendConfig)
 }
 
 func TestConfiguration_NewLogger(t *testing.T) {

--- a/server/common/feature_flags.go
+++ b/server/common/feature_flags.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -24,10 +25,8 @@ func ValidateFeatureFlag(value string) (err error) {
 
 // ValidateCustomFeatureFlag validates a feature flag string value against a list of possible values
 func ValidateCustomFeatureFlag(value string, possibleValues []string) (err error) {
-	for _, possibleValue := range possibleValues {
-		if value == possibleValue {
-			return nil
-		}
+	if slices.Contains(possibleValues, value) {
+		return nil
 	}
 	return fmt.Errorf("Invalid feature flag value. Expecting : %s", strings.Join(possibleValues, "|"))
 }

--- a/server/common/paging.go
+++ b/server/common/paging.go
@@ -67,13 +67,13 @@ func (pq *PagingQuery) Paginator() *paginator.Paginator {
 
 // PagingResponse for the paging system
 type PagingResponse struct {
-	After   *string       `json:"after"`
-	Before  *string       `json:"before"`
-	Results []interface{} `json:"results"`
+	After   *string `json:"after"`
+	Before  *string `json:"before"`
+	Results []any   `json:"results"`
 }
 
 // NewPagingResponse create a new PagingResponse from query results ( results must be a slice )
-func NewPagingResponse(results interface{}, cursor *paginator.Cursor) (pr *PagingResponse) {
+func NewPagingResponse(results any, cursor *paginator.Cursor) (pr *PagingResponse) {
 	pr = &PagingResponse{}
 	pr.Results = utils.ToInterfaceArray(results)
 	pr.Before = cursor.Before

--- a/server/common/paging_test.go
+++ b/server/common/paging_test.go
@@ -33,7 +33,7 @@ func TestPagingQuery_Paginator(t *testing.T) {
 }
 
 func TestNewPagingResponse(t *testing.T) {
-	results := append([]interface{}{}, 1, 2, 3)
+	results := append([]any{}, 1, 2, 3)
 	before := "before"
 	after := "after"
 	pagingResponse := NewPagingResponse(results, &paginator.Cursor{Before: &before, After: &after})

--- a/server/common/utils.go
+++ b/server/common/utils.go
@@ -69,7 +69,7 @@ func EncodeAuthBasicHeader(login string, password string) (value string) {
 }
 
 // WriteJSONResponse serialize the response to json and write it to the HTTP response body
-func WriteJSONResponse(resp http.ResponseWriter, obj interface{}) {
+func WriteJSONResponse(resp http.ResponseWriter, obj any) {
 	json, err := utils.ToJson(obj)
 	if err != nil {
 		panic(fmt.Errorf("unable to serialize json response : %s", err))

--- a/server/context/errors.go
+++ b/server/context/errors.go
@@ -32,37 +32,37 @@ func (ctx *Context) InternalServerError(message string, err error) {
 }
 
 // BadRequest is a helper to generate http.BadRequest responses
-func (ctx *Context) BadRequest(message string, params ...interface{}) {
+func (ctx *Context) BadRequest(message string, params ...any) {
 	message = fmt.Sprintf(message, params...)
 	ctx.Fail(message, nil, http.StatusBadRequest)
 }
 
 // NotFound is a helper to generate http.NotFound responses
-func (ctx *Context) NotFound(message string, params ...interface{}) {
+func (ctx *Context) NotFound(message string, params ...any) {
 	message = fmt.Sprintf(message, params...)
 	ctx.Fail(message, nil, http.StatusNotFound)
 }
 
 // Forbidden is a helper to generate http.Forbidden responses
-func (ctx *Context) Forbidden(message string, params ...interface{}) {
+func (ctx *Context) Forbidden(message string, params ...any) {
 	message = fmt.Sprintf(message, params...)
 	ctx.Fail(message, nil, http.StatusForbidden)
 }
 
 // Unauthorized is a helper to generate http.Unauthorized responses
-func (ctx *Context) Unauthorized(message string, params ...interface{}) {
+func (ctx *Context) Unauthorized(message string, params ...any) {
 	message = fmt.Sprintf(message, params...)
 	ctx.Fail(message, nil, http.StatusUnauthorized)
 }
 
 // MissingParameter is a helper to generate http.BadRequest responses
-func (ctx *Context) MissingParameter(message string, params ...interface{}) {
+func (ctx *Context) MissingParameter(message string, params ...any) {
 	message = fmt.Sprintf(message, params...)
 	ctx.BadRequest(fmt.Sprintf("missing %s", message))
 }
 
 // InvalidParameter is a helper to generate http.BadRequest responses
-func (ctx *Context) InvalidParameter(message string, params ...interface{}) {
+func (ctx *Context) InvalidParameter(message string, params ...any) {
 	message = fmt.Sprintf(message, params...)
 	ctx.BadRequest(fmt.Sprintf("invalid %s", message))
 }

--- a/server/context/upload_test.go
+++ b/server/context/upload_test.go
@@ -561,7 +561,7 @@ func TestCreateWithFilenameTooLong(t *testing.T) {
 
 	file := &common.File{}
 	params.Files = append(params.Files, file)
-	for i := 0; i < 2048; i++ {
+	for range 2048 {
 		file.Name += "x"
 	}
 
@@ -621,7 +621,7 @@ func TestCheckUserFreeSpaceForUploadNoUser(t *testing.T) {
 	ctx := newTestContext()
 
 	params := &common.Upload{}
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		file := &common.File{Name: "foo", Size: 10 * 1e9}
 		params.Files = append(params.Files, file)
 	}
@@ -645,7 +645,7 @@ func TestCheckUserFreeSpaceForUploadUploadTooBig(t *testing.T) {
 	ctx.user = &common.User{MaxUserSize: 1024}
 
 	params := &common.Upload{}
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		file := &common.File{Name: "foo", Size: 10 * 1e9}
 		params.Files = append(params.Files, file)
 	}
@@ -683,7 +683,7 @@ func testUploadSize(t *testing.T, ok bool) {
 	require.NoError(t, err)
 
 	params := &common.Upload{User: ctx.user.ID}
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		file := &common.File{Name: "foo", Size: 10}
 		params.Files = append(params.Files, file)
 	}

--- a/server/data/file/file.go
+++ b/server/data/file/file.go
@@ -21,7 +21,7 @@ type Config struct {
 
 // NewConfig instantiate a new default configuration
 // and override it with configuration passed as argument
-func NewConfig(params map[string]interface{}) (config *Config) {
+func NewConfig(params map[string]any) (config *Config) {
 	config = new(Config)
 	config.Directory = "files" // Default upload directory is ./files
 	utils.Assign(config, params)

--- a/server/data/file/file_test.go
+++ b/server/data/file/file_test.go
@@ -29,7 +29,7 @@ func newBackend(t *testing.T) (backend *Backend, cleanup func()) {
 }
 
 func TestNewFileBackendConfig(t *testing.T) {
-	config := NewConfig(make(map[string]interface{}))
+	config := NewConfig(make(map[string]any))
 	require.NotNil(t, config, "invalid nil config")
 }
 

--- a/server/data/gcs/gcs.go
+++ b/server/data/gcs/gcs.go
@@ -23,7 +23,7 @@ type Config struct {
 
 // NewConfig instantiate a new default configuration
 // and override it with configuration passed as argument
-func NewConfig(params map[string]interface{}) (config *Config) {
+func NewConfig(params map[string]any) (config *Config) {
 	config = new(Config)
 	utils.Assign(config, params)
 	return config

--- a/server/data/s3/s3.go
+++ b/server/data/s3/s3.go
@@ -31,7 +31,7 @@ type Config struct {
 
 // NewConfig instantiate a new default configuration
 // and override it with configuration passed as argument
-func NewConfig(params map[string]interface{}) (config *Config) {
+func NewConfig(params map[string]any) (config *Config) {
 	config = new(Config)
 	config.Bucket = "plik"
 	config.Location = "us-east-1"

--- a/server/data/stream/stream_test.go
+++ b/server/data/stream/stream_test.go
@@ -20,14 +20,12 @@ func TestAddGetFile(t *testing.T) {
 	upload.InitializeForTests()
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		time.Sleep(10 * time.Millisecond)
 		err := backend.AddFile(file, bytes.NewBufferString("data"))
 		require.NoError(t, err, "unable to add file")
 		require.NotNil(t, file.BackendDetails, "invalid nil details")
-		wg.Done()
-	}()
+	})
 
 	f := func() {
 		for {

--- a/server/data/swift/swift.go
+++ b/server/data/swift/swift.go
@@ -23,7 +23,7 @@ type Config struct {
 
 // NewConfig instantiate a new default configuration
 // and override it with configuration passed as argument
-func NewConfig(params map[string]interface{}) (config *Config) {
+func NewConfig(params map[string]any) (config *Config) {
 	config = new(Config)
 	config.Container = "plik"
 	utils.Assign(config, params)

--- a/server/handlers/add_file_test.go
+++ b/server/handlers/add_file_test.go
@@ -314,7 +314,7 @@ func TestAddFileTooManyFiles(t *testing.T) {
 
 	upload := &common.Upload{IsAdmin: true}
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		upload.NewFile()
 	}
 	createTestUpload(t, ctx, upload)

--- a/server/handlers/admin_test.go
+++ b/server/handlers/admin_test.go
@@ -141,7 +141,7 @@ func createTestUploads(t *testing.T, ctx *context.Context) {
 func getOrder(t *testing.T, response common.PagingResponse) []int {
 	order := make([]int, len(response.Results))
 	for idx, u := range response.Results {
-		upload := u.(map[string]interface{})
+		upload := u.(map[string]any)
 		i, err := strconv.Atoi(upload["comments"].(string))
 		require.NoError(t, err)
 		order[idx] = i
@@ -318,7 +318,7 @@ func TestGetServerStatistics(t *testing.T) {
 	ctx := newTestingContext(common.NewConfiguration())
 	createAdminUser(t, ctx)
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		upload := &common.Upload{}
 		file := upload.NewFile()
 		file.Size = 2
@@ -328,7 +328,7 @@ func TestGetServerStatistics(t *testing.T) {
 		require.NoError(t, err, "create error")
 	}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		upload := &common.Upload{}
 		upload.User = ctx.GetUser().ID
 		file := upload.NewFile()

--- a/server/handlers/get_archive_test.go
+++ b/server/handlers/get_archive_test.go
@@ -120,7 +120,7 @@ func TestGetArchiveFileNameTooLong(t *testing.T) {
 	ctx.SetUpload(upload)
 
 	archiveName := ""
-	for i := 0; i < 10240; i++ {
+	for range 10240 {
 		archiveName += "x"
 	}
 	archiveName += ".zip"

--- a/server/handlers/google.go
+++ b/server/handlers/google.go
@@ -103,7 +103,7 @@ func GoogleCallback(ctx *context.Context, resp http.ResponseWriter, req *http.Re
 	}
 
 	/* Parse state */
-	state, err := jwt.Parse(b64state, func(token *jwt.Token) (interface{}, error) {
+	state, err := jwt.Parse(b64state, func(token *jwt.Token) (any, error) {
 		// Verify signing algorithm
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected siging method : %v", token.Header["alg"])

--- a/server/handlers/google_test.go
+++ b/server/handlers/google_test.go
@@ -52,7 +52,7 @@ func TestGoogleLogin(t *testing.T) {
 	URL, err := url.Parse(string(respBody))
 	require.NoError(t, err, "unable to parse google auth url")
 
-	state, err := jwt.Parse(URL.Query().Get("state"), func(token *jwt.Token) (interface{}, error) {
+	state, err := jwt.Parse(URL.Query().Get("state"), func(token *jwt.Token) (any, error) {
 		// Verify signing algorithm
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			t.Fatalf("Unexpected siging method : %v", token.Header["alg"])

--- a/server/handlers/me.go
+++ b/server/handlers/me.go
@@ -97,7 +97,7 @@ func RemoveUserUploads(ctx *context.Context, resp http.ResponseWriter, req *http
 		return
 	}
 
-	_, _ = resp.Write([]byte(fmt.Sprintf("%d uploads removed", deleted)))
+	_, _ = resp.Write(fmt.Appendf(nil, "%d uploads removed", deleted))
 }
 
 // GetUserStatistics return the user statistics

--- a/server/handlers/oidc.go
+++ b/server/handlers/oidc.go
@@ -34,7 +34,7 @@ type oidcClaims struct {
 func (c *oidcClaims) UnmarshalJSON(data []byte) error {
 	type alias oidcClaims
 	aux := &struct {
-		EmailVerified interface{} `json:"email_verified"`
+		EmailVerified any `json:"email_verified"`
 		*alias
 	}{
 		alias: (*alias)(c),
@@ -361,7 +361,7 @@ func OIDCCallback(ctx *context.Context, resp http.ResponseWriter, req *http.Requ
 		return
 	}
 
-	state, err := jwt.Parse(b64state, func(token *jwt.Token) (interface{}, error) {
+	state, err := jwt.Parse(b64state, func(token *jwt.Token) (any, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}

--- a/server/handlers/oidc_test.go
+++ b/server/handlers/oidc_test.go
@@ -72,7 +72,7 @@ func makeTestIDToken(claims oidcClaims) string {
 // which standard json.Marshal skips due to the json:"-" tag.
 func marshalOIDCClaimsForTest(claims oidcClaims) []byte {
 	data, _ := json.Marshal(claims)
-	var m map[string]interface{}
+	var m map[string]any
 	_ = json.Unmarshal(data, &m)
 	if claims.EmailVerified != nil {
 		m["email_verified"] = *claims.EmailVerified
@@ -93,7 +93,7 @@ func oidcMockHandler(opts oidcMockOptions) http.HandlerFunc {
 		case "/.well-known/openid-configuration":
 			responseBody, _ = json.Marshal(oidcTestDiscovery)
 		case "/token":
-			tokenResp := map[string]interface{}{
+			tokenResp := map[string]any{
 				"access_token":  "access_token",
 				"token_type":    "Bearer",
 				"refresh_token": "refresh_token",
@@ -169,7 +169,7 @@ func TestOIDCLogin(t *testing.T) {
 	URL, err := url.Parse(string(respBody))
 	require.NoError(t, err, "unable to parse OIDC auth url")
 
-	state, err := jwt.Parse(URL.Query().Get("state"), func(token *jwt.Token) (interface{}, error) {
+	state, err := jwt.Parse(URL.Query().Get("state"), func(token *jwt.Token) (any, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			t.Fatalf("Unexpected signing method: %v", token.Header["alg"])
 		}
@@ -582,13 +582,14 @@ func TestOIDCCallbackDomainValidationNoEmail(t *testing.T) {
 	context.TestForbidden(t, rr, "email is required when domain validation is enabled")
 }
 
-func boolPtr(b bool) *bool { return &b }
+//go:fix inline
+func boolPtr(b bool) *bool { return new(b) }
 
 func TestParseIDTokenClaims(t *testing.T) {
 	idClaims := oidcClaims{
 		Sub:               "id-sub",
 		Email:             "id@example.com",
-		EmailVerified:     boolPtr(true),
+		EmailVerified:     new(true),
 		Name:              "ID Name",
 		GivenName:         "ID",
 		FamilyName:        "Name",
@@ -603,7 +604,7 @@ func TestParseIDTokenClaims(t *testing.T) {
 		AccessToken: "access",
 		TokenType:   "Bearer",
 	}
-	token = token.WithExtra(map[string]interface{}{
+	token = token.WithExtra(map[string]any{
 		"id_token": idToken,
 	})
 
@@ -671,15 +672,15 @@ func TestMergeClaimsNilUserinfo(t *testing.T) {
 }
 
 func TestMergeClaimsEmailVerifiedOverride(t *testing.T) {
-	idToken := &oidcClaims{Sub: "sub", EmailVerified: boolPtr(true)}
-	userinfo := &oidcClaims{Sub: "sub", EmailVerified: boolPtr(false)}
+	idToken := &oidcClaims{Sub: "sub", EmailVerified: new(true)}
+	userinfo := &oidcClaims{Sub: "sub", EmailVerified: new(false)}
 	merged := mergeClaims(idToken, userinfo)
 	require.NotNil(t, merged.EmailVerified)
 	require.False(t, *merged.EmailVerified, "userinfo email_verified=false should override id_token's true")
 }
 
 func TestMergeClaimsNoCopy(t *testing.T) {
-	userinfo := &oidcClaims{Sub: "sub", Name: "original", EmailVerified: boolPtr(true)}
+	userinfo := &oidcClaims{Sub: "sub", Name: "original", EmailVerified: new(true)}
 	merged := mergeClaims(nil, userinfo)
 	merged.Name = "mutated"
 	require.Equal(t, "original", userinfo.Name, "merge must return a copy, not alias the input")
@@ -688,7 +689,7 @@ func TestMergeClaimsNoCopy(t *testing.T) {
 }
 
 func TestMergeClaimsNoCopyBothPresent(t *testing.T) {
-	idToken := &oidcClaims{Sub: "sub", EmailVerified: boolPtr(true)}
+	idToken := &oidcClaims{Sub: "sub", EmailVerified: new(true)}
 	userinfo := &oidcClaims{Sub: "sub"}
 	merged := mergeClaims(idToken, userinfo)
 	require.NotNil(t, merged.EmailVerified)
@@ -705,7 +706,7 @@ func TestParseIDTokenClaimsEmailVerifiedString(t *testing.T) {
 	mc["sub"] = "string-ev-user"
 	mc["email_verified"] = "true"
 	signed, _ := rawJWT.SignedString([]byte("key"))
-	token = token.WithExtra(map[string]interface{}{"id_token": signed})
+	token = token.WithExtra(map[string]any{"id_token": signed})
 
 	parsed, err := parseIDTokenClaims(token)
 	require.NoError(t, err)
@@ -721,7 +722,7 @@ func TestParseIDTokenClaimsEmailVerifiedNumeric(t *testing.T) {
 	mc["sub"] = "numeric-ev-user"
 	mc["email_verified"] = float64(1)
 	signed, _ := rawJWT.SignedString([]byte("key"))
-	token = token.WithExtra(map[string]interface{}{"id_token": signed})
+	token = token.WithExtra(map[string]any{"id_token": signed})
 
 	parsed, err := parseIDTokenClaims(token)
 	require.NoError(t, err)
@@ -732,7 +733,7 @@ func TestParseIDTokenClaimsEmailVerifiedNumeric(t *testing.T) {
 
 func TestParseIDTokenClaimsMalformed(t *testing.T) {
 	token := &oauth2.Token{AccessToken: "access", TokenType: "Bearer"}
-	token = token.WithExtra(map[string]interface{}{"id_token": "not.a.valid-jwt"})
+	token = token.WithExtra(map[string]any{"id_token": "not.a.valid-jwt"})
 
 	parsed, err := parseIDTokenClaims(token)
 	require.Error(t, err)
@@ -825,7 +826,7 @@ func TestOIDCCallbackRequireVerifiedEmail(t *testing.T) {
 	idTokenClaims := oidcClaims{
 		Sub:           "verified-user",
 		Email:         "verified@root.gg",
-		EmailVerified: boolPtr(true),
+		EmailVerified: new(true),
 		Name:          "Verified User",
 	}
 
@@ -859,7 +860,7 @@ func TestOIDCCallbackRequireVerifiedEmailFalse(t *testing.T) {
 	idTokenClaims := oidcClaims{
 		Sub:           "unverified-user",
 		Email:         "unverified@root.gg",
-		EmailVerified: boolPtr(false),
+		EmailVerified: new(false),
 		Name:          "Unverified User",
 	}
 
@@ -973,43 +974,43 @@ func TestOIDCClaimsUnmarshalJSON(t *testing.T) {
 		{
 			name:         "bool true",
 			json:         `{"sub":"s","email_verified":true}`,
-			wantVerified: boolPtr(true),
+			wantVerified: new(true),
 			wantSub:      "s",
 		},
 		{
 			name:         "bool false",
 			json:         `{"sub":"s","email_verified":false}`,
-			wantVerified: boolPtr(false),
+			wantVerified: new(false),
 			wantSub:      "s",
 		},
 		{
 			name:         "string true",
 			json:         `{"sub":"s","email_verified":"true"}`,
-			wantVerified: boolPtr(true),
+			wantVerified: new(true),
 			wantSub:      "s",
 		},
 		{
 			name:         "string True (case insensitive)",
 			json:         `{"sub":"s","email_verified":"True"}`,
-			wantVerified: boolPtr(true),
+			wantVerified: new(true),
 			wantSub:      "s",
 		},
 		{
 			name:         "string false",
 			json:         `{"sub":"s","email_verified":"false"}`,
-			wantVerified: boolPtr(false),
+			wantVerified: new(false),
 			wantSub:      "s",
 		},
 		{
 			name:         "numeric 1",
 			json:         `{"sub":"s","email_verified":1}`,
-			wantVerified: boolPtr(true),
+			wantVerified: new(true),
 			wantSub:      "s",
 		},
 		{
 			name:         "numeric 0",
 			json:         `{"sub":"s","email_verified":0}`,
-			wantVerified: boolPtr(false),
+			wantVerified: new(false),
 			wantSub:      "s",
 		},
 		{
@@ -1064,7 +1065,7 @@ func TestOIDCCallbackEmailVerifiedFromUserinfo(t *testing.T) {
 	// email_verified comes exclusively from userinfo
 	userinfoClaims := oidcClaims{
 		Sub:           "userinfo-ev-user",
-		EmailVerified: boolPtr(true),
+		EmailVerified: new(true),
 	}
 
 	_, shutdown, err := common.StartAPIMockServerCustomPort(common.APIMockServerDefaultPort, oidcMockHandler(oidcMockOptions{

--- a/server/handlers/ovh.go
+++ b/server/handlers/ovh.go
@@ -171,7 +171,7 @@ func OvhCallback(ctx *context.Context, resp http.ResponseWriter, req *http.Reque
 	}
 
 	// Parse session cookie
-	ovhAuthCookie, err := jwt.Parse(ovhSessionCookie.Value, func(t *jwt.Token) (interface{}, error) {
+	ovhAuthCookie, err := jwt.Parse(ovhSessionCookie.Value, func(t *jwt.Token) (any, error) {
 		// Verify signing algorithm
 		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("unexpected siging method : %v", t.Header["alg"])
@@ -214,14 +214,14 @@ func OvhCallback(ctx *context.Context, resp http.ResponseWriter, req *http.Reque
 
 	// Sign request
 	h := sha1.New()
-	h.Write([]byte(fmt.Sprintf("%s+%s+%s+%s+%s+%d",
+	h.Write(fmt.Appendf(nil, "%s+%s+%s+%s+%s+%d",
 		config.OvhAPISecret,
 		ovhConsumerKey.(string),
 		"GET",
 		url,
 		"",
 		timestamp,
-	)))
+	))
 	ovhReq.Header.Add("X-Ovh-Signature", fmt.Sprintf("$1$%x", h.Sum(nil)))
 
 	// Do request

--- a/server/handlers/ovh_test.go
+++ b/server/handlers/ovh_test.go
@@ -74,7 +74,7 @@ func TestOVHLogin(t *testing.T) {
 	}
 	require.NotEqual(t, "", stateString, "context.TestPanic(t, rr,")
 
-	ovhAuthCookie, err := jwt.Parse(stateString, func(t *jwt.Token) (interface{}, error) {
+	ovhAuthCookie, err := jwt.Parse(stateString, func(t *jwt.Token) (any, error) {
 		// Verify signing algorithm
 		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("Unexpected siging method : %v", t.Header["alg"])

--- a/server/metadata/exporter.go
+++ b/server/metadata/exporter.go
@@ -23,7 +23,7 @@ const (
 
 type object struct {
 	Type   metadataType
-	Object interface{}
+	Object any
 }
 
 type exporter struct {

--- a/server/metadata/logger.go
+++ b/server/metadata/logger.go
@@ -31,17 +31,17 @@ func (l *GormLoggerAdapter) LogMode(level gorm_logger.LogLevel) gorm_logger.Inte
 }
 
 // Info print info
-func (l *GormLoggerAdapter) Info(ctx context.Context, msg string, data ...interface{}) {
+func (l *GormLoggerAdapter) Info(ctx context.Context, msg string, data ...any) {
 	l.logger.Infof(msg, data...)
 }
 
 // Warn print warn messages
-func (l *GormLoggerAdapter) Warn(ctx context.Context, msg string, data ...interface{}) {
+func (l *GormLoggerAdapter) Warn(ctx context.Context, msg string, data ...any) {
 	l.logger.Warningf(msg, data...)
 }
 
 // Error print error messages
-func (l *GormLoggerAdapter) Error(ctx context.Context, msg string, data ...interface{}) {
+func (l *GormLoggerAdapter) Error(ctx context.Context, msg string, data ...any) {
 	l.logger.Criticalf(msg, data...)
 }
 

--- a/server/metadata/metadata.go
+++ b/server/metadata/metadata.go
@@ -33,7 +33,7 @@ type Config struct {
 
 // NewConfig instantiate a new default configuration
 // and override it with configuration passed as argument
-func NewConfig(params map[string]interface{}) (config *Config) {
+func NewConfig(params map[string]any) (config *Config) {
 	config = new(Config)
 	config.Driver = "sqlite3"
 	config.ConnectionString = "plik.db"

--- a/server/metadata/metadata_test.go
+++ b/server/metadata/metadata_test.go
@@ -55,7 +55,7 @@ func shutdownTestMetadataBackend(b *Backend) {
 }
 
 func TestNewConfig(t *testing.T) {
-	params := make(map[string]interface{})
+	params := make(map[string]any)
 	params["Driver"] = "driver"
 	params["ConnectionString"] = "connection string"
 	params["EraseFirst"] = true
@@ -160,7 +160,7 @@ func TestGormConcurrent(t *testing.T) {
 	count := 30
 	var wg sync.WaitGroup
 	errors := make(chan error, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
@@ -189,7 +189,7 @@ func TestMetadataConcurrent(t *testing.T) {
 	count := 30
 	var wg sync.WaitGroup
 	errors := make(chan error, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()

--- a/server/metadata/migrations_test.go
+++ b/server/metadata/migrations_test.go
@@ -161,7 +161,7 @@ func loadSQLDump(t *testing.T, path string) {
 	// Filter out psql meta-commands (lines starting with \) that are not valid SQL.
 	// PostgreSQL 18+ pg_dump emits \restrict/\unrestrict for sandboxing.
 	var filteredLines []string
-	for _, line := range strings.Split(string(sqldump), "\n") {
+	for line := range strings.SplitSeq(string(sqldump), "\n") {
 		if !strings.HasPrefix(line, `\`) {
 			filteredLines = append(filteredLines, line)
 		}

--- a/server/metadata/token_test.go
+++ b/server/metadata/token_test.go
@@ -52,7 +52,7 @@ func TestBackend_GetTokens(t *testing.T) {
 	defer shutdownTestMetadataBackend(b)
 
 	user := common.NewUser(common.ProviderLocal, "user")
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		user.NewToken()
 	}
 	createUser(t, b, user)
@@ -93,7 +93,7 @@ func TestBackend_CountUserTokens(t *testing.T) {
 	defer shutdownTestMetadataBackend(b)
 
 	user := common.NewUser(common.ProviderLocal, "user")
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		user.NewToken()
 	}
 	createUser(t, b, user)

--- a/server/metadata/upload_test.go
+++ b/server/metadata/upload_test.go
@@ -103,7 +103,7 @@ func TestBackend_GetUploads(t *testing.T) {
 	require.Nil(t, cursor.Before, "invalid non nil before cursor")
 	require.NotNil(t, cursor.After, "invalid nil after cursor")
 
-	for i := 0; i < limit; i++ {
+	for i := range limit {
 		require.Equal(t, fmt.Sprintf("%d", 100-i), uploads[i].Comments, "invalid upload sequence")
 	}
 
@@ -115,7 +115,7 @@ func TestBackend_GetUploads(t *testing.T) {
 	require.NotNil(t, cursor.Before, "invalid nil before cursor")
 	require.NotNil(t, cursor.After, "invalid nil after cursor")
 
-	for i := 0; i < limit; i++ {
+	for i := range limit {
 		require.Equal(t, fmt.Sprintf("%d", 100-limit-i), uploads[i].Comments, "invalid upload sequence")
 	}
 
@@ -127,7 +127,7 @@ func TestBackend_GetUploads(t *testing.T) {
 	require.Nil(t, cursor.Before, "invalid non nil before cursor")
 	require.NotNil(t, cursor.After, "invalid nil after cursor")
 
-	for i := 0; i < limit; i++ {
+	for i := range limit {
 		require.Equal(t, fmt.Sprintf("%d", 100-i), uploads[i].Comments, "invalid upload sequence")
 	}
 }
@@ -173,7 +173,7 @@ func TestBackend_GetUploads_User(t *testing.T) {
 	require.Len(t, uploads, limit, "invalid upload count")
 	require.NotNil(t, cursor, "invalid nil cursor")
 
-	for i := 0; i < limit; i++ {
+	for i := range limit {
 		expected := 100 - i*10
 		require.Equal(t, fmt.Sprintf("%d", expected), uploads[i].Comments, "invalid upload sequence")
 	}
@@ -229,7 +229,7 @@ func TestBackend_GetUploadsAsc(t *testing.T) {
 	require.Nil(t, cursor.Before, "invalid non nil before cursor")
 	require.NotNil(t, cursor.After, "invalid nil after cursor")
 
-	for i := 0; i < limit; i++ {
+	for i := range limit {
 		require.Equal(t, fmt.Sprintf("%d", i+1), uploads[i].Comments, "invalid upload sequence")
 	}
 
@@ -241,7 +241,7 @@ func TestBackend_GetUploadsAsc(t *testing.T) {
 	require.NotNil(t, cursor.Before, "invalid nil before cursor")
 	require.NotNil(t, cursor.After, "invalid nil after cursor")
 
-	for i := 0; i < limit; i++ {
+	for i := range limit {
 		require.Equal(t, fmt.Sprintf("%d", i+limit+1), uploads[i].Comments, "invalid upload sequence")
 	}
 
@@ -253,7 +253,7 @@ func TestBackend_GetUploadsAsc(t *testing.T) {
 	require.Nil(t, cursor.Before, "invalid non nil before cursor")
 	require.NotNil(t, cursor.After, "invalid nil after cursor")
 
-	for i := 0; i < limit; i++ {
+	for i := range limit {
 		require.Equal(t, fmt.Sprintf("%d", i+1), uploads[i].Comments, "invalid upload sequence")
 	}
 }
@@ -278,7 +278,7 @@ func TestBackend_GetUploadsSortedBySize(t *testing.T) {
 	require.Nil(t, cursor.Before, "invalid non nil before cursor")
 	require.NotNil(t, cursor.After, "invalid nil after cursor")
 
-	for i := 0; i < limit; i++ {
+	for i := range limit {
 		require.Equal(t, fmt.Sprintf("%d", 100-i), uploads[i].Comments, "invalid upload sequence")
 	}
 
@@ -290,7 +290,7 @@ func TestBackend_GetUploadsSortedBySize(t *testing.T) {
 	require.NotNil(t, cursor.Before, "invalid nil before cursor")
 	require.NotNil(t, cursor.After, "invalid nil after cursor")
 
-	for i := 0; i < limit; i++ {
+	for i := range limit {
 		require.Equal(t, fmt.Sprintf("%d", 100-limit-i), uploads[i].Comments, "invalid upload sequence")
 	}
 
@@ -302,7 +302,7 @@ func TestBackend_GetUploadsSortedBySize(t *testing.T) {
 	require.Nil(t, cursor.Before, "invalid non nil before cursor")
 	require.NotNil(t, cursor.After, "invalid nil after cursor")
 
-	for i := 0; i < limit; i++ {
+	for i := range limit {
 		require.Equal(t, fmt.Sprintf("%d", 100-i), uploads[i].Comments, "invalid upload sequence")
 	}
 }
@@ -349,7 +349,7 @@ func TestBackend_GetUploadsSortedBySizeAsc(t *testing.T) {
 	require.Nil(t, cursor.Before, "invalid non nil before cursor")
 	require.NotNil(t, cursor.After, "invalid nil after cursor")
 
-	for i := 0; i < limit; i++ {
+	for i := range limit {
 		require.Equal(t, fmt.Sprintf("%d", i+1), uploads[i].Comments, "invalid upload sequence")
 	}
 
@@ -361,7 +361,7 @@ func TestBackend_GetUploadsSortedBySizeAsc(t *testing.T) {
 	require.NotNil(t, cursor.Before, "invalid nil before cursor")
 	require.NotNil(t, cursor.After, "invalid nil after cursor")
 
-	for i := 0; i < limit; i++ {
+	for i := range limit {
 		require.Equal(t, fmt.Sprintf("%d", i+limit+1), uploads[i].Comments, "invalid upload sequence")
 	}
 
@@ -373,7 +373,7 @@ func TestBackend_GetUploadsSortedBySizeAsc(t *testing.T) {
 	require.Nil(t, cursor.Before, "invalid non nil before cursor")
 	require.NotNil(t, cursor.After, "invalid nil after cursor")
 
-	for i := 0; i < limit; i++ {
+	for i := range limit {
 		require.Equal(t, fmt.Sprintf("%d", i+1), uploads[i].Comments, "invalid upload sequence")
 	}
 }
@@ -401,7 +401,7 @@ func TestBackend_GetUploadsSortedBySize_User(t *testing.T) {
 	require.Len(t, uploads, limit, "invalid upload count")
 	require.NotNil(t, cursor, "invalid nil cursor")
 
-	for i := 0; i < limit; i++ {
+	for i := range limit {
 		expected := 100 - i*10
 		require.Equal(t, fmt.Sprintf("%d", expected), uploads[i].Comments, "invalid upload sequence")
 	}

--- a/server/metadata/user_test.go
+++ b/server/metadata/user_test.go
@@ -93,12 +93,12 @@ func TestBackend_GetUsers(t *testing.T) {
 	b := newTestMetadataBackend()
 	defer shutdownTestMetadataBackend(b)
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		user := common.NewUser(common.ProviderLocal, fmt.Sprintf("user_%d", i))
 		createUser(t, b, user)
 	}
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		user := common.NewUser(common.ProviderGoogle, fmt.Sprintf("user_%d", i))
 		createUser(t, b, user)
 	}
@@ -146,20 +146,20 @@ func TestBackend_ForEachUserUploads(t *testing.T) {
 	token := user.NewToken()
 	createUser(t, b, user)
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		upload := &common.Upload{}
 		upload.User = user.ID
 		createUpload(t, b, upload)
 	}
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		upload := &common.Upload{}
 		upload.User = user.ID
 		upload.Token = token.Token
 		createUpload(t, b, upload)
 	}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		upload := &common.Upload{}
 		upload.User = "blah"
 		createUpload(t, b, upload)
@@ -201,20 +201,20 @@ func TestBackend_DeleteUserUploads(t *testing.T) {
 	token := user.NewToken()
 	createUser(t, b, user)
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		upload := &common.Upload{}
 		upload.User = user.ID
 		createUpload(t, b, upload)
 	}
 
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		upload := &common.Upload{}
 		upload.User = user.ID
 		upload.Token = token.Token
 		createUpload(t, b, upload)
 	}
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		upload := &common.Upload{}
 		upload.User = "blah"
 		createUpload(t, b, upload)

--- a/server/middleware/upload_test.go
+++ b/server/middleware/upload_test.go
@@ -117,7 +117,7 @@ func TestUploadExtendTTL(t *testing.T) {
 		"uploadID": upload.ID,
 	}
 
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		req = mux.SetURLVars(req, vars)
 		rr := ctx.NewRecorder(req)
 		Upload(ctx, common.DummyHandler).ServeHTTP(rr, req)

--- a/server/server/server.go
+++ b/server/server/server.go
@@ -166,7 +166,7 @@ func (ps *PlikServer) start() (err error) {
 	log.Infof("Starting plikd server v%s", common.GetBuildInfo().Version)
 
 	log.Debug("Configuration :")
-	for _, line := range strings.Split(ps.config.String(), "\n") {
+	for line := range strings.SplitSeq(ps.config.String(), "\n") {
 		if line != "" {
 			log.Debug(line)
 		}
@@ -429,7 +429,7 @@ func (ps *PlikServer) WithMetadataBackend(backend *metadata.Backend) *PlikServer
 }
 
 // NewMetadataBackend Initialize metadata backend from metadata backend configuration
-func NewMetadataBackend(params map[string]interface{}, log *logger.Logger) (backend *metadata.Backend, err error) {
+func NewMetadataBackend(params map[string]any, log *logger.Logger) (backend *metadata.Backend, err error) {
 	return metadata.NewBackend(metadata.NewConfig(params), log)
 }
 
@@ -456,7 +456,7 @@ func (ps *PlikServer) WithDataBackend(backend data.Backend) *PlikServer {
 }
 
 // NewDataBackend Initialize data backend from type and data backend configuration
-func NewDataBackend(impl string, params map[string]interface{}) (backend data.Backend, err error) {
+func NewDataBackend(impl string, params map[string]any) (backend data.Backend, err error) {
 	switch impl {
 	case "file":
 		backend = file.NewBackend(file.NewConfig(params))
@@ -525,7 +525,7 @@ func (ps *PlikServer) initializeAuthenticator() (err error) {
 			return fmt.Errorf("metadata backend must be initialized before the authenticator")
 		}
 
-		for i := 0; i < 2; i++ {
+		for range 2 {
 			setting, err := ps.metadataBackend.GetSetting(common.AuthenticationSignatureKeySettingKey)
 			if err != nil {
 				return fmt.Errorf("unable to get authentication signature key : %s", err)


### PR DESCRIPTION
## Summary

Add `go fix` to the build tooling and apply it across the entire codebase.

### Changes

- **Makefile**: Add `go fix ./...` as a third check in the `make lint` target (alongside `go fmt` and `go vet`)
- **Makefile**: Add standalone `make gofix` target for running `go fix` independently
- **Go source files**: Apply `go fix` auto-corrections across all packages (53 files, mostly minor modernizations)
- **AGENTS.md**: Document the new `make gofix` target and updated `make lint` description

### Why

`go fix` rewrites code to use newer Go APIs and patterns. Including it in `make lint` ensures future code stays up to date with Go language evolutions automatically.