### PR TITLE
webapp: improve upload error handling with per-file retry

### DIFF
--- a/webapp/ARCHITECTURE.md
+++ b/webapp/ARCHITECTURE.md
@@ -157,6 +157,18 @@ try {
 
 > **Why**: Calling `resp.json()` first consumes the body stream. If it fails (plain text response), `resp.text()` would then also fail with "body stream already read". The text-first approach avoids this.
 
+### Network error wrapping
+
+`apiCall` wraps `fetch()` in a try/catch to convert the browser's generic `TypeError: Failed to fetch` into a user-friendly `"Network error — server may be unreachable"`. Without this, network failures (offline, DNS, server down) surface as cryptic browser errors.
+
+### XHR upload errors
+
+`uploadFile` uses XHR (not fetch) for progress tracking. The server returns **plain text** errors, not JSON, so the XHR error handler uses the same two-pass pattern: try `JSON.parse`, fall back to `xhr.responseText`. The `error` event (network failure) produces `"Upload connection lost — check your network"` instead of the generic browser error.
+
+### Error display format
+
+Error messages include the HTTP status code when available: `"message (HTTP 404)"`. File upload errors in the banner include the filename: `"photo.jpg: file too big"`. This gives users enough context to understand what went wrong and report issues.
+
 ### Success responses
 
 Some endpoints return **plain text** on success:
@@ -181,9 +193,34 @@ DownloadView uses **two separate error refs** to avoid upload errors from hiding
 | Ref | Purpose | Display |
 |-----|---------|---------|
 | `error` | Page-level failures (e.g., `fetchUpload` fails, upload not found) | Full-page error state via `v-else-if="error"` — replaces entire content |
-| `uploadError` | File transfer failures (e.g., 400 Bad Request during upload) | Dismissible inline banner within the upload content area |
+| `uploadError` | Non-file operational errors (reserved for future use) | Dismissible inline banner within the upload content area |
 
 > **Why two refs**: The template uses `v-if="loading"` / `v-else-if="error"` / `v-else-if="upload"` branching. If file upload errors set `error`, the `v-else-if="error"` branch takes over and hides the sidebar + file list. The `uploadError` ref keeps errors in the `v-else-if="upload"` block so the user retains context.
+
+### Per-file error handling with retry
+
+File upload errors are shown **per-file in the pending panel**, not in a top banner. Failed files:
+- Stay in the pending panel with `status: 'error'` and a red error message
+- Have a **Retry** button (per-file) and a **Retry Failed** button (bulk)
+- Have a dismiss (X) button to remove them from the list
+- Keep `isAddingFiles = true` so they don't appear as "Waiting for upload" in the top panel
+- When retried, transition back to `status: 'toUpload'` and re-enter the upload pool
+
+### Upload pool architecture
+
+All upload logic is DRY across three entry points:
+
+| Function | Purpose |
+|---|---|
+| `uploadFileEntry(file)` | Shared helper: XHR upload, progress, success/error handling |
+| `uploadPendingFiles()` | Pool manager: concurrency-limited batch with re-check loop |
+| `retryFile(file)` / `retryAllFailed()` | Reset file(s) to `toUpload`, delegate to pool |
+
+Key design decisions:
+- **`isUploading`** (non-reactive) guards pool re-entry. Separate from `isAddingFiles` (reactive, UI display).
+- **`activeBasicAuth`** stored at component level so retries preserve password-protected upload credentials.
+- **Re-check loop**: after each batch completes, the pool re-scans for `toUpload` files. This lets retries queue into the existing pool without bypassing `MAX_CONCURRENT`.
+- **`cancelAllUploads`** calls `fetchUpload()` after a 200ms delay so the server has time to update metadata.
 
 ---
 

--- a/webapp/src/api.js
+++ b/webapp/src/api.js
@@ -42,7 +42,13 @@ async function apiCall(url, method = 'GET', data = null, headers = {}) {
         opts.body = JSON.stringify(data)
     }
 
-    const resp = await fetch(url, opts)
+    let resp
+    try {
+        resp = await fetch(url, opts)
+    } catch (err) {
+        // Network errors (offline, DNS, CORS, server down)
+        throw { status: 0, message: 'Network error \u2014 server may be unreachable', originalError: err.message }
+    }
 
     if (!resp.ok) {
         let message = 'Unknown error'
@@ -257,17 +263,20 @@ export function uploadFile(upload, fileEntry, onProgress, basicAuth, onStart) {
                     resolve(null)
                 }
             } else {
-                let message = 'Upload failed'
+                let message = `Upload failed (${xhr.status})`
                 try {
                     const body = JSON.parse(xhr.responseText)
                     message = body.message || message
-                } catch { /* ignore */ }
+                } catch {
+                    // Server returns plain text errors (not JSON)
+                    if (xhr.responseText) message = xhr.responseText
+                }
                 reject({ status: xhr.status, message })
             }
         })
 
         xhr.addEventListener('error', () => {
-            reject({ status: 0, message: 'Connection failed' })
+            reject({ status: 0, message: 'Upload connection lost \u2014 check your network' })
         })
 
         xhr.addEventListener('abort', () => {

--- a/webapp/src/components/FileRow.vue
+++ b/webapp/src/components/FileRow.vue
@@ -12,7 +12,7 @@ const props = defineProps({
   isStream: { type: Boolean, default: false },
 })
 
-const emit = defineEmits(['remove', 'update-name', 'show-qr', 'view', 'cancel'])
+const emit = defineEmits(['remove', 'update-name', 'show-qr', 'view', 'cancel', 'retry'])
 
 // For streaming uploads, files in 'uploading' status have a valid download URL
 // (the server streams from uploader to downloader). Files in 'missing' status
@@ -159,13 +159,21 @@ function fileUrl() {
         </div>
 
         <!-- Upload error indicator -->
-        <div v-if="mode === 'uploading' && file.status === 'error'" class="mt-1">
+        <div v-if="mode === 'uploading' && file.status === 'error'" class="mt-1 flex items-center gap-2">
           <span class="text-xs text-danger-500 flex items-center gap-1">
             <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
             </svg>
             {{ file.error || 'Upload failed' }}
           </span>
+          <button class="text-xs text-accent-400 hover:text-accent-300 transition-colors flex items-center gap-0.5"
+                  title="Retry upload"
+                  @click="emit('retry', file)">
+            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+            </svg>
+            Retry
+          </button>
         </div>
       </div>
 
@@ -233,6 +241,16 @@ function fileUrl() {
                 class="btn bg-danger-500/10 text-danger-500 hover:bg-danger-500/20 px-2 py-1.5 text-xs"
                 title="Cancel upload"
                 @click="emit('cancel', file)">
+          <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+
+        <!-- Remove button (error state — dismiss failed upload) -->
+        <button v-if="mode === 'uploading' && file.status === 'error'"
+                class="btn bg-danger-500/10 text-danger-500 hover:bg-danger-500/20 px-2 py-1.5 text-xs"
+                title="Dismiss"
+                @click="emit('remove', file)">
           <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
           </svg>

--- a/webapp/src/views/DownloadView.vue
+++ b/webapp/src/views/DownloadView.vue
@@ -64,7 +64,10 @@ async function viewFile(file) {
   try {
     const url = getFileURL(props.id, file.id, file.fileName)
     const resp = await fetch(url, { credentials: 'same-origin' })
-    if (!resp.ok) throw new Error(`Failed to fetch file (${resp.status})`)
+    if (!resp.ok) {
+      const text = await resp.text().catch(() => '')
+      throw new Error(text || `Failed to load file (HTTP ${resp.status})`)
+    }
     const text = await resp.text()
     viewingContent.value = text
   } catch (err) {
@@ -124,7 +127,9 @@ async function fetchUpload() {
   try {
     upload.value = await getUpload(props.id, uploadToken.value)
   } catch (err) {
-    error.value = err.message || 'Failed to load upload'
+    error.value = err.status
+      ? `${err.message} (HTTP ${err.status})`
+      : (err.message || 'Failed to load upload')
   } finally {
     loading.value = false
   }
@@ -205,12 +210,17 @@ async function cancelFileUpload(file) {
   }
   pendingFiles.value = pendingFiles.value.filter(f => f.reference !== file.reference)
 
+  // If no more active/error files, exit upload mode
+  if (!pendingFiles.value.some(f => f.status === 'uploading' || f.status === 'toUpload' || f.status === 'error')) {
+    isAddingFiles.value = false
+  }
+
   // Give the server time to clean up the aborted file (uploading → removed → deleted)
   await new Promise(resolve => setTimeout(resolve, 200))
   await fetchUpload()
 }
 
-function cancelAllUploads() {
+async function cancelAllUploads() {
   uploadsCancelled = true
   for (const file of pendingFiles.value) {
     if (file.abort) {
@@ -219,78 +229,129 @@ function cancelAllUploads() {
   }
   pendingFiles.value = []
   isAddingFiles.value = false
+
+  // Give the server time to clean up aborted files before refreshing
+  await new Promise(resolve => setTimeout(resolve, 200))
+  await fetchUpload()
 }
 
+// --- Shared upload helpers ---
+
+const MAX_CONCURRENT = 5
+
+// BasicAuth stored at component level so retries preserve credentials
+let activeBasicAuth = null
+
+// Whether the upload pool is currently running (re-entry guard)
+let isUploading = false
+
+// Locally update a server file's status (reactive, no full refresh needed)
+function setServerFileStatus(fileId, status) {
+  const serverFile = upload.value?.files?.find(f => f.id === fileId)
+  if (serverFile) serverFile.status = status
+}
+
+// Upload a single file entry (shared by pool and individual retry)
+function uploadFileEntry(fileEntry) {
+  fileEntry.status = 'uploading'
+  fileEntry.error = null
+  fileEntry.progress = 0
+
+  const isStream = upload.value.stream
+
+  const { promise, abort } = uploadFile(
+    { id: props.id, stream: isStream, uploadToken: uploadToken.value },
+    { id: fileEntry.id, fileName: fileEntry.fileName, file: fileEntry.file },
+    (progress) => { fileEntry.progress = progress },
+    activeBasicAuth,
+    isStream ? () => setServerFileStatus(fileEntry.id, 'uploading') : undefined,
+  )
+
+  fileEntry.abort = abort
+
+  return promise.then((result) => {
+    fileEntry.status = 'uploaded'
+    fileEntry.id = result.id
+    setServerFileStatus(result.id, 'uploaded')
+    // Remove from pending panel immediately
+    pendingFiles.value = pendingFiles.value.filter(f => f.reference !== fileEntry.reference)
+  }).catch((err) => {
+    if (!err.cancelled) {
+      fileEntry.status = 'error'
+      fileEntry.error = err.message || 'Upload failed'
+    }
+  })
+}
+
+// Check if we should exit upload mode
+function checkUploadModeExit() {
+  const hasErrors = pendingFiles.value.some(f => f.status === 'error')
+  const hasActive = pendingFiles.value.some(f => f.status === 'uploading' || f.status === 'toUpload')
+  if (!hasErrors && !hasActive) {
+    isAddingFiles.value = false
+  }
+}
+
+// --- Upload pool ---
+
 async function uploadPendingFiles() {
-  if (!pendingFiles.value.length || isAddingFiles.value) return
+  if (!pendingFiles.value.length || isUploading) return
+  isUploading = true
   isAddingFiles.value = true
   uploadsCancelled = false
 
-  const basicAuth = pendingBasicAuth
+  activeBasicAuth = pendingBasicAuth || activeBasicAuth
   pendingBasicAuth = null
 
-  const isStream = upload.value.stream
-  const filesToUpload = [...pendingFiles.value]
-    .filter(fileEntry => pendingFiles.value.includes(fileEntry))
+  // Re-check loop: after each batch, pick up files that were retried mid-batch
+  while (!uploadsCancelled) {
+    const filesToUpload = pendingFiles.value.filter(f => f.status === 'toUpload')
+    if (!filesToUpload.length) break
 
-  // Locally update a server file's status (reactive, no full refresh needed)
-  function setServerFileStatus(fileId, status) {
-    const serverFile = upload.value?.files?.find(f => f.id === fileId)
-    if (serverFile) serverFile.status = status
-  }
-
-  // Upload a single file entry
-  function doUpload(fileEntry) {
-    if (uploadsCancelled) return Promise.resolve()
-
-    fileEntry.status = 'uploading'
-
-    const { promise, abort } = uploadFile(
-      { id: props.id, stream: isStream, uploadToken: uploadToken.value },
-      { id: fileEntry.id, fileName: fileEntry.fileName, file: fileEntry.file },
-      (progress) => { fileEntry.progress = progress },
-      basicAuth,
-      // For streaming: mark server file as 'uploading' on connection open
-      // so it appears in the top panel with a working download link
-      isStream ? () => setServerFileStatus(fileEntry.id, 'uploading') : undefined,
-    )
-
-    fileEntry.abort = abort
-
-    return promise.then((result) => {
-      fileEntry.status = 'uploaded'
-      fileEntry.id = result.id
-      // Locally mark server file as uploaded — appears in top panel
-      setServerFileStatus(result.id, 'uploaded')
-    }).catch((err) => {
-      if (!err.cancelled) {
-        fileEntry.status = 'error'
-        fileEntry.error = err.message || 'Upload failed'
-        uploadError.value = err.message || `Failed to upload ${fileEntry.fileName}`
-        // No local status change on error — file stays in bottom panel
+    const queue = [...filesToUpload]
+    const workers = Array.from({ length: Math.min(MAX_CONCURRENT, queue.length) }, async () => {
+      while (queue.length > 0 && !uploadsCancelled) {
+        const fileEntry = queue.shift()
+        await uploadFileEntry(fileEntry)
       }
     })
+
+    await Promise.allSettled(workers)
   }
 
-  // Concurrency-limited pool: max 5 uploads at a time
-  const MAX_CONCURRENT = 5
-  const queue = [...filesToUpload]
-  const workers = Array.from({ length: Math.min(MAX_CONCURRENT, queue.length) }, async () => {
-    while (queue.length > 0 && !uploadsCancelled) {
-      const fileEntry = queue.shift()
-      await doUpload(fileEntry)
-    }
-  })
-
-  await Promise.allSettled(workers)
-
-  // Clear completed/errored pending files, keep only remaining toUpload files
-  pendingFiles.value = pendingFiles.value.filter(f => f.status === 'toUpload')
-  isAddingFiles.value = false
+  isUploading = false
+  checkUploadModeExit()
 
   // Final refresh to sync with server truth
   if (!uploadsCancelled) {
     await fetchUpload()
+  }
+}
+
+// --- Retry (funnel through standard upload pool) ---
+
+function retryFile(file) {
+  file.status = 'toUpload'
+  file.error = null
+  file.progress = 0
+  file.abort = null
+  if (!isUploading) {
+    uploadPendingFiles()
+  }
+  // If pool is running, the re-check loop picks it up after the current batch
+}
+
+function retryAllFailed() {
+  for (const file of pendingFiles.value) {
+    if (file.status === 'error') {
+      file.status = 'toUpload'
+      file.error = null
+      file.progress = 0
+      file.abort = null
+    }
+  }
+  if (!isUploading) {
+    uploadPendingFiles()
   }
 }
 
@@ -338,17 +399,39 @@ onMounted(async () => {
   }
 })
 
-// Auto-show view panel if there is exactly one text file
+// When the upload ID changes (e.g. user pastes a different URL), reset and re-fetch
+watch(() => props.id, async (newId, oldId) => {
+  if (newId === oldId) return
+
+  // Reset all state
+  upload.value = null
+  error.value = null
+  uploadError.value = null
+  pendingFiles.value = []
+  isAddingFiles.value = false
+  closeViewer()
+  lastAutoViewedId.value = null
+
+  // Handle uploadToken in query
+  const queryToken = router.currentRoute.value.query.uploadToken
+  if (queryToken) {
+    setToken(newId, queryToken)
+    router.replace({ path: '/', query: { id: newId } })
+  }
+
+  await fetchUpload()
+})
+
+// Auto-show view panel if the upload contains exactly one file and it's a text file
 watch(activeFiles, (files) => {
-  if (files.length === 1) {
-    const file = files[0]
-    if (file.status === 'uploaded' && isTextFile(file) && lastAutoViewedId.value !== file.id) {
-      lastAutoViewedId.value = file.id
-      viewFile(file)
-    }
-  } else if (files.length > 1) {
-    // If more files added, we might want to reset scroll but keep viewer if it was manually opened.
-    // However, the requirement is only for "if upload has only one file".
+  // Only auto-view when the entire upload has exactly one file
+  const totalUploadFiles = upload.value?.files?.filter(f => f.status !== 'removed' && f.status !== 'deleted')
+  if (totalUploadFiles?.length !== 1) return
+
+  const file = files[0]
+  if (file?.status === 'uploaded' && isTextFile(file) && lastAutoViewedId.value !== file.id) {
+    lastAutoViewedId.value = file.id
+    viewFile(file)
   }
 }, { immediate: true })
 </script>
@@ -489,18 +572,28 @@ watch(activeFiles, (files) => {
           <div v-if="pendingFiles.length" class="space-y-2">
             <div class="flex items-center justify-between px-1">
               <h3 class="text-sm font-medium text-surface-400">
-                <template v-if="isAddingFiles">
+                <template v-if="isAddingFiles && pendingFiles.some(f => f.status === 'error') && !pendingFiles.some(f => f.status === 'uploading' || f.status === 'toUpload')">
+                  {{ pendingFiles.filter(f => f.status === 'error').length }} file{{ pendingFiles.filter(f => f.status === 'error').length > 1 ? 's' : '' }} failed
+                </template>
+                <template v-else-if="isAddingFiles">
                   {{ pendingFiles.filter(f => f.status !== 'uploaded').length }} file{{ pendingFiles.filter(f => f.status !== 'uploaded').length > 1 ? 's' : '' }} left to upload
                 </template>
                 <template v-else>
                   {{ pendingFiles.length }} file{{ pendingFiles.length > 1 ? 's' : '' }} to add
                 </template>
               </h3>
-              <button v-if="isAddingFiles"
-                      class="text-xs text-danger-500 hover:text-danger-400 transition-colors"
-                      @click="cancelAllUploads">
-                Cancel All
-              </button>
+              <div class="flex items-center gap-3">
+                <button v-if="isAddingFiles && pendingFiles.some(f => f.status === 'error') && !pendingFiles.some(f => f.status === 'uploading' || f.status === 'toUpload')"
+                        class="text-xs text-accent-400 hover:text-accent-300 transition-colors"
+                        @click="retryAllFailed">
+                  Retry Failed
+                </button>
+                <button v-if="isAddingFiles"
+                        class="text-xs text-danger-500 hover:text-danger-400 transition-colors"
+                        @click="cancelAllUploads">
+                  Cancel All
+                </button>
+              </div>
             </div>
 
             <FileRow v-for="file in pendingFiles"
@@ -508,7 +601,8 @@ watch(activeFiles, (files) => {
                      :file="file"
                      :mode="isAddingFiles ? 'uploading' : 'upload'"
                      @remove="isAddingFiles ? cancelFileUpload(file) : removePendingFile(file)"
-                     @cancel="cancelFileUpload" />
+                     @cancel="cancelFileUpload"
+                     @retry="retryFile" />
           </div>
 
           <!-- Upload Pending Files Button (only shown when files are staged but not yet uploading) -->
@@ -523,7 +617,7 @@ watch(activeFiles, (files) => {
           </div>
 
           <!-- Upload progress indicator -->
-          <div v-if="isAddingFiles" class="flex items-center justify-center py-2">
+          <div v-if="isAddingFiles && pendingFiles.some(f => f.status === 'uploading' || f.status === 'toUpload')" class="flex items-center justify-center py-2">
             <div class="animate-spin rounded-full h-4 w-4 border-2 border-accent-500 border-t-transparent" />
             <span class="ml-2 text-xs text-surface-400">Uploading files...</span>
           </div>

--- a/webapp/src/views/UploadView.vue
+++ b/webapp/src/views/UploadView.vue
@@ -232,7 +232,9 @@ async function createEmptyUpload() {
     setToken(upload.id, upload.uploadToken)
     router.push({ path: '/', query: { id: upload.id } })
   } catch (err) {
-    uploadError.value = err.message || 'Failed to create upload'
+    uploadError.value = err.status
+      ? `${err.message} (HTTP ${err.status})`
+      : (err.message || 'Failed to create upload')
   } finally {
     isUploading.value = false
   }
@@ -265,7 +267,9 @@ async function doUpload() {
     setToken(upload.id, upload.uploadToken)
     router.push({ path: '/', query: { id: upload.id } })
   } catch (err) {
-    uploadError.value = err.message || 'Failed to create upload'
+    uploadError.value = err.status
+      ? `${err.message} (HTTP ${err.status})`
+      : (err.message || 'Failed to create upload')
   } finally {
     isUploading.value = false
   }


### PR DESCRIPTION
## Summary

Improve the upload error handling UX with per-file error display, retry functionality, and a refactored upload pool architecture.

### Error message improvements
- **Network errors**: `"Failed to fetch"` → `"Network error — server may be unreachable"`
- **XHR upload errors**: Parse plain-text server errors (e.g. `"file too big"`) instead of `"Upload failed"`
- **Connection drops**: `"Connection failed"` → `"Upload connection lost — check your network"`
- **HTTP status codes**: Included in error messages where available (e.g. `"upload not found (HTTP 404)"`)

### Per-file retry
- File upload errors shown **per-file in the pending panel** with red error text — no top banner
- **Retry** button per-file + **Retry Failed** bulk button + dismiss (X)
- Failed files stay in pending panel (`isAddingFiles = true`), spinner hidden when only errors remain

### Upload pool refactor (DRY)
- Extracted `uploadFileEntry()`, `setServerFileStatus()`, `checkUploadModeExit()` as shared helpers
- `retryFile()` / `retryAllFailed()` funnel through standard pool respecting `MAX_CONCURRENT = 5`
- `activeBasicAuth` preserved at component level for retries
- Separate `isUploading` (re-entry guard) vs `isAddingFiles` (reactive UI flag)
- Re-check loop picks up retried files without bypassing concurrency limits

### Other fixes
- `cancelAllUploads` syncs server state via `fetchUpload()` after 200ms delay
- `DownloadView` re-fetches on upload ID change (URL navigation without page reload)
- Auto-view text file only when upload has exactly 1 file total