### PR TITLE
Block messaging app link preview bots from downloading one-shot/streaming files

### DIFF
--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -80,3 +80,21 @@ Set `FeatureAuthentication = "forced"` to require authentication for all uploads
 ### Upload Tokens
 
 Authenticated users can generate upload tokens to link CLI uploads to their account. Tokens are sent via the `X-PlikToken` HTTP header.
+
+## Link Preview Bot Protection
+
+Messaging apps like Slack, Telegram, WhatsApp, Signal, Discord, and others generate link previews by fetching shared URLs. This is problematic for:
+
+- **One-shot uploads**: the bot's preview request counts as the single allowed download, deleting the file before the intended recipient can access it
+- **Streaming uploads**: the bot consumes the stream data, leaving nothing for the real downloader
+
+Plik automatically blocks known messaging app link preview bots from downloading one-shot and streaming files, returning a **406 Not Acceptable** response. Normal (multi-download) uploads are not affected — bots can still generate previews for those.
+
+::: tip No configuration needed
+This protection is always active and requires no configuration. It uses a hardcoded list of known bot user-agent strings that is maintained with Plik releases.
+:::
+
+### Blocked Bots
+
+Slack, Telegram, WhatsApp, Signal, Facebook/Messenger, Discord, Skype, Viber, LinkedIn, Twitter/X, Microsoft Teams, Wire, Mattermost, Rocket.Chat, and Zulip.
+

--- a/server/ARCHITECTURE.md
+++ b/server/ARCHITECTURE.md
@@ -205,6 +205,7 @@ Each middleware is a function that takes a `context.Context` and optionally call
 | `create_upload.go` | `CreateUpload` | Parse upload creation params for quick upload |
 | `paginate.go` | `Paginate` | Parse pagination query params |
 | `redirect.go` | `RedirectOnFailure` | Redirect to webapp on error (for browser requests) |
+| `block_bot_download.go` | `BlockBotDownload` | Block messaging app link preview bots from downloading one-shot/streaming files (returns 406) |
 | `user.go` | `User` | Resolve `{userID}` → load user (admin or self) |
 
 ---

--- a/server/context/errors.go
+++ b/server/context/errors.go
@@ -49,6 +49,12 @@ func (ctx *Context) Forbidden(message string, params ...any) {
 	ctx.Fail(message, nil, http.StatusForbidden)
 }
 
+// NotAcceptable is a helper to generate http.StatusNotAcceptable responses
+func (ctx *Context) NotAcceptable(message string, params ...any) {
+	message = fmt.Sprintf(message, params...)
+	ctx.Fail(message, nil, http.StatusNotAcceptable)
+}
+
 // Unauthorized is a helper to generate http.Unauthorized responses
 func (ctx *Context) Unauthorized(message string, params ...any) {
 	message = fmt.Sprintf(message, params...)

--- a/server/middleware/block_bot_download.go
+++ b/server/middleware/block_bot_download.go
@@ -1,0 +1,74 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/root-gg/plik/server/context"
+)
+
+// blockedUserAgents contains substrings found in User-Agent headers
+// of messaging app link preview bots. These bots fetch URLs to generate
+// previews, which would consume one-shot downloads or streaming data.
+var blockedUserAgents = []string{
+	"Slackbot",
+	"TelegramBot",
+	"WhatsApp",
+	"Signal",
+	"facebookexternalhit", // Facebook / Messenger
+	"Facebot",             // Facebook / Messenger
+	"Discordbot",
+	"SkypeUriPreview",
+	"Viber",
+	"LinkedInBot",
+	"Twitterbot", // X / Twitter
+	"Wire",
+	"Mattermost",
+	"Rocket.Chat",
+	"Zulip",
+	"Teams",            // Microsoft Teams
+	"MicrosoftPreview", // Microsoft Teams link preview
+}
+
+// IsBlockedUserAgent checks if the request comes from a known
+// messaging app link preview bot
+func IsBlockedUserAgent(req *http.Request) bool {
+	ua := req.Header.Get("User-Agent")
+	if ua == "" {
+		return false
+	}
+	for _, blocked := range blockedUserAgents {
+		if strings.Contains(ua, blocked) {
+			return true
+		}
+	}
+	return false
+}
+
+// BlockBotDownload blocks messaging app link preview bots from downloading
+// one-shot and streaming files. These bots generate link previews which
+// would consume the single download opportunity or the stream data,
+// preventing the real recipient from accessing the file.
+func BlockBotDownload(ctx *context.Context, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		// Only block GET requests (HEAD is harmless for one-shot/stream)
+		if req.Method != "GET" {
+			next.ServeHTTP(resp, req)
+			return
+		}
+
+		upload := ctx.GetUpload()
+		if upload == nil {
+			// Let the handler panic with the appropriate message
+			next.ServeHTTP(resp, req)
+			return
+		}
+
+		if (upload.OneShot || upload.Stream) && IsBlockedUserAgent(req) {
+			ctx.NotAcceptable("Messaging app link preview bots are not allowed to download one-shot or streaming files")
+			return
+		}
+
+		next.ServeHTTP(resp, req)
+	})
+}

--- a/server/middleware/block_bot_download_test.go
+++ b/server/middleware/block_bot_download_test.go
@@ -1,0 +1,134 @@
+package middleware
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/root-gg/plik/server/common"
+	"github.com/root-gg/plik/server/context"
+)
+
+func TestIsBlockedUserAgent(t *testing.T) {
+	tests := []struct {
+		name      string
+		userAgent string
+		blocked   bool
+	}{
+		{"Slackbot", "Slackbot-LinkExpanding 1.0 (+https://api.slack.com/robots)", true},
+		{"TelegramBot", "TelegramBot (like TwitterBot)", true},
+		{"WhatsApp", "WhatsApp/2.23.20.0", true},
+		{"Signal", "Signal/6.30.1", true},
+		{"Facebook", "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatype.php)", true},
+		{"Facebot", "Facebot", true},
+		{"Discord", "Mozilla/5.0 (compatible; Discordbot/2.0; +https://discordapp.com)", true},
+		{"Skype", "SkypeUriPreview Preview/0.5", true},
+		{"LinkedIn", "LinkedInBot/1.0 (compatible; Mozilla/5.0;)", true},
+		{"Twitter", "Twitterbot/1.0", true},
+		{"Teams", "MicrosoftPreview/2.0 +https://aka.ms/browserpolicydoc", true},
+		{"Mattermost", "Mattermost-Bot/1.1", true},
+		{"Normal browser", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36", false},
+		{"Curl", "curl/7.68.0", false},
+		{"Go client", "Go-http-client/1.1", false},
+		{"Plik client", "plik_client/1.3.0", false},
+		{"Empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest("GET", "/file/test", &bytes.Buffer{})
+			require.NoError(t, err)
+			if tt.userAgent != "" {
+				req.Header.Set("User-Agent", tt.userAgent)
+			}
+			require.Equal(t, tt.blocked, IsBlockedUserAgent(req))
+		})
+	}
+}
+
+func TestBlockBotDownloadOneShotBlocked(t *testing.T) {
+	ctx := newTestingContext(common.NewConfiguration())
+
+	upload := &common.Upload{OneShot: true}
+	upload.InitializeForTests()
+	ctx.SetUpload(upload)
+
+	req, err := http.NewRequest("GET", "/file/test", &bytes.Buffer{})
+	require.NoError(t, err)
+	req.Header.Set("User-Agent", "Slackbot-LinkExpanding 1.0")
+
+	rr := ctx.NewRecorder(req)
+	BlockBotDownload(ctx, common.DummyHandler).ServeHTTP(rr, req)
+
+	context.TestFail(t, rr, http.StatusNotAcceptable, "link preview bots are not allowed")
+}
+
+func TestBlockBotDownloadStreamingBlocked(t *testing.T) {
+	ctx := newTestingContext(common.NewConfiguration())
+
+	upload := &common.Upload{Stream: true}
+	upload.InitializeForTests()
+	ctx.SetUpload(upload)
+
+	req, err := http.NewRequest("GET", "/file/test", &bytes.Buffer{})
+	require.NoError(t, err)
+	req.Header.Set("User-Agent", "WhatsApp/2.23.20.0")
+
+	rr := ctx.NewRecorder(req)
+	BlockBotDownload(ctx, common.DummyHandler).ServeHTTP(rr, req)
+
+	context.TestFail(t, rr, http.StatusNotAcceptable, "link preview bots are not allowed")
+}
+
+func TestBlockBotDownloadNormalUploadAllowed(t *testing.T) {
+	ctx := newTestingContext(common.NewConfiguration())
+
+	upload := &common.Upload{}
+	upload.InitializeForTests()
+	ctx.SetUpload(upload)
+
+	req, err := http.NewRequest("GET", "/file/test", &bytes.Buffer{})
+	require.NoError(t, err)
+	req.Header.Set("User-Agent", "Slackbot-LinkExpanding 1.0")
+
+	rr := ctx.NewRecorder(req)
+	BlockBotDownload(ctx, common.DummyHandler).ServeHTTP(rr, req)
+
+	context.TestOK(t, rr)
+}
+
+func TestBlockBotDownloadNormalUserAgentOneShotAllowed(t *testing.T) {
+	ctx := newTestingContext(common.NewConfiguration())
+
+	upload := &common.Upload{OneShot: true}
+	upload.InitializeForTests()
+	ctx.SetUpload(upload)
+
+	req, err := http.NewRequest("GET", "/file/test", &bytes.Buffer{})
+	require.NoError(t, err)
+	req.Header.Set("User-Agent", "curl/7.68.0")
+
+	rr := ctx.NewRecorder(req)
+	BlockBotDownload(ctx, common.DummyHandler).ServeHTTP(rr, req)
+
+	context.TestOK(t, rr)
+}
+
+func TestBlockBotDownloadHEADAllowed(t *testing.T) {
+	ctx := newTestingContext(common.NewConfiguration())
+
+	upload := &common.Upload{OneShot: true}
+	upload.InitializeForTests()
+	ctx.SetUpload(upload)
+
+	req, err := http.NewRequest("HEAD", "/file/test", &bytes.Buffer{})
+	require.NoError(t, err)
+	req.Header.Set("User-Agent", "Slackbot-LinkExpanding 1.0")
+
+	rr := ctx.NewRecorder(req)
+	BlockBotDownload(ctx, common.DummyHandler).ServeHTTP(rr, req)
+
+	context.TestOK(t, rr)
+}

--- a/server/server/server.go
+++ b/server/server/server.go
@@ -351,7 +351,7 @@ func (ps *PlikServer) getHTTPHandler() (handler http.Handler) {
 	tokenChainWithRedirect := context.NewChain(middleware.RedirectOnFailure).AppendChain(tokenChain)
 
 	// Chain that fetches the requested upload and file metadata
-	getFileChain := context.NewChain(middleware.Upload, middleware.File)
+	getFileChain := context.NewChain(middleware.Upload, middleware.BlockBotDownload, middleware.File)
 	userChain := authenticatedChain.Append(middleware.User)
 
 	// HTTP Api routes configuration
@@ -372,7 +372,7 @@ func (ps *PlikServer) getHTTPHandler() (handler http.Handler) {
 	router.Handle("/file/{uploadID}/{fileID}/{filename}", tokenChainWithRedirect.AppendChain(getFileChain).Then(handlers.GetFile)).Methods("HEAD", "GET")
 	router.Handle("/stream/{uploadID}/{fileID}/{filename}", tokenChain.AppendChain(getFileChain).Then(handlers.AddFile)).Methods("POST")
 	router.Handle("/stream/{uploadID}/{fileID}/{filename}", tokenChainWithRedirect.AppendChain(getFileChain).Then(handlers.GetFile)).Methods("HEAD", "GET")
-	router.Handle("/archive/{uploadID}/{filename}", tokenChainWithRedirect.Append(middleware.Upload).Then(handlers.GetArchive)).Methods("HEAD", "GET")
+	router.Handle("/archive/{uploadID}/{filename}", tokenChainWithRedirect.Append(middleware.Upload, middleware.BlockBotDownload).Then(handlers.GetArchive)).Methods("HEAD", "GET")
 
 	router.Handle("/auth/google/login", authChain.Then(handlers.GoogleLogin)).Methods("GET")
 	router.Handle("/auth/google/callback", stdChainWithRedirect.Then(handlers.GoogleCallback)).Methods("GET")


### PR DESCRIPTION
## Summary

Messaging apps (Slack, Telegram, WhatsApp, Signal, Messenger, Discord, etc.) generate link previews by fetching download URLs. For **one-shot** uploads this consumes the single download — the file is deleted before the intended recipient can access it. For **streaming** uploads the bot consumes the stream data.

This PR adds a `BlockBotDownload` middleware that detects known messaging app user agents and returns **406 Not Acceptable** when they attempt to `GET` files from one-shot or streaming uploads. Normal (multi-download) uploads are unaffected.

Closes #365

## Changes

- **New** `server/middleware/block_bot_download.go` — middleware with hardcoded list of 16 known bot user-agent substrings
- **New** `server/middleware/block_bot_download_test.go` — 7 test functions (17 sub-tests for UA matching + 5 middleware behavior tests)
- **Modified** `server/context/errors.go` — added `ctx.NotAcceptable()` helper (HTTP 406)
- **Modified** `server/server/server.go` — wired middleware into file/stream/archive download chains
- **Modified** `server/ARCHITECTURE.md` — documented new middleware
- **Modified** `docs/guide/security.md` — added \"Link Preview Bot Protection\" section to user docs

## Blocked Bots

`Slackbot`, `TelegramBot`, `WhatsApp`, `Signal`, `facebookexternalhit`, `Facebot`, `Discordbot`, `SkypeUriPreview`, `Viber`, `LinkedInBot`, `Twitterbot`, `Wire`, `Mattermost`, `Rocket.Chat`, `Zulip`, `Teams`, `MicrosoftPreview`"