### PR TITLE
fix: add darwin/arm64 to client build targets

### DIFF
--- a/releaser/build_clients.sh
+++ b/releaser/build_clients.sh
@@ -13,7 +13,7 @@ RELEASE_VERSION=$(server/gen_build_info.sh version)
 
 # Default client targets
 if [[ -z "$CLIENT_TARGETS" ]]; then
-  CLIENT_TARGETS="darwin/amd64,freebsd/386,freebsd/amd64,linux/386,linux/amd64,linux/arm,linux/arm64,openbsd/386,openbsd/amd64,windows/amd64,windows/386"
+  CLIENT_TARGETS="darwin/amd64,darwin/arm64,freebsd/386,freebsd/amd64,linux/386,linux/amd64,linux/arm,linux/arm64,openbsd/386,openbsd/amd64,windows/amd64,windows/386"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Add `darwin/arm64` to the `CLIENT_TARGETS` list in `releaser/build_clients.sh` so that Apple Silicon (M1/M2/M3/M4) Macs get a native pre-built client binary.

Closes #606