### PR TITLE
feat(client): add --json output flag and redirect all prints to stderr

### DIFF
--- a/client/ARCHITECTURE.md
+++ b/client/ARCHITECTURE.md
@@ -37,7 +37,10 @@ Uses [docopt-go](https://github.com/docopt/docopt-go) for argument parsing. The 
 4. Create upload via the Go library (`plik/`)
 5. Add files (with optional archive/encrypt preprocessing)
 6. Upload files with progress bars
-7. Print download URLs
+7. Output results:
+   - Default: print download URLs/commands to stdout
+   - `--quiet`: print only file URLs to stdout
+   - `--json`: print `UploadWithURL` as pretty-printed JSON to stdout (implies `--quiet`)
 
 ### Configuration (`config.go`)
 
@@ -107,3 +110,20 @@ All upload tools use `plik.UploadParams` via struct embedding and return `Upload
 
 - `test.sh` — comprehensive CLI integration tests (requires a running server)
 - `test_upgrade.sh` / `test_downgrade.sh` — version compatibility tests (stale, unused since ~2021)
+
+---
+
+## Conventions
+
+### Stderr for all non-data output
+
+Because `--quiet` and `--json` modes reserve stdout exclusively for machine-readable data (file URLs or JSON), **all** informational, diagnostic, and error messages in the CLI must be written to **stderr** (`fmt.Fprintf(os.Stderr, ...)`). This includes:
+
+- Passphrase display (crypto backends)
+- Recipient resolution progress (age backend)
+- Debug output
+- Streaming download commands
+- Archive/crypto error messages
+- Progress bars (already write to stderr via the `pb` library)
+
+Never use `fmt.Printf` / `fmt.Println` for non-data output in the CLI.

--- a/client/archive/tar/tar.go
+++ b/client/archive/tar/tar.go
@@ -42,7 +42,7 @@ func (tb *Backend) Configure(arguments map[string]any) (err error) {
 // Archive implementation for TAR Archive Backend
 func (tb *Backend) Archive(files []string) (reader io.Reader, err error) {
 	if len(files) == 0 {
-		fmt.Println("Unable to make a tar archive from STDIN")
+		fmt.Fprintln(os.Stderr, "Unable to make a tar archive from STDIN")
 		os.Exit(1)
 		return
 	}
@@ -64,19 +64,19 @@ func (tb *Backend) Archive(files []string) (reader io.Reader, err error) {
 	go func() {
 		err := cmd.Start()
 		if err != nil {
-			fmt.Printf("Unable to run tar cmd : %s\n", err)
+			fmt.Fprintf(os.Stderr, "Unable to run tar cmd : %s\n", err)
 			os.Exit(1)
 			return
 		}
 		err = cmd.Wait()
 		if err != nil {
-			fmt.Printf("Unable to run tar cmd : %s\n", err)
+			fmt.Fprintf(os.Stderr, "Unable to run tar cmd : %s\n", err)
 			os.Exit(1)
 			return
 		}
 		err = writer.Close()
 		if err != nil {
-			fmt.Printf("Unable to run tar cmd : %s\n", err)
+			fmt.Fprintf(os.Stderr, "Unable to run tar cmd : %s\n", err)
 			os.Exit(1)
 			return
 		}

--- a/client/archive/zip/zip.go
+++ b/client/archive/zip/zip.go
@@ -39,7 +39,7 @@ func (zb *Backend) Configure(arguments map[string]any) (err error) {
 // Archive implementation for ZIP Archive Backend
 func (zb *Backend) Archive(files []string) (reader io.Reader, err error) {
 	if len(files) == 0 {
-		fmt.Println("Unable to make a zip archive from STDIN")
+		fmt.Fprintln(os.Stderr, "Unable to make a zip archive from STDIN")
 		os.Exit(1)
 		return
 	}
@@ -57,19 +57,19 @@ func (zb *Backend) Archive(files []string) (reader io.Reader, err error) {
 	go func() {
 		err := cmd.Start()
 		if err != nil {
-			fmt.Printf("Unable to run zip cmd : %s\n", err)
+			fmt.Fprintf(os.Stderr, "Unable to run zip cmd : %s\n", err)
 			os.Exit(1)
 			return
 		}
 		err = cmd.Wait()
 		if err != nil {
-			fmt.Printf("Unable to run zip cmd : %s\n", err)
+			fmt.Fprintf(os.Stderr, "Unable to run zip cmd : %s\n", err)
 			os.Exit(1)
 			return
 		}
 		err = writer.Close()
 		if err != nil {
-			fmt.Printf("Unable to run zip cmd : %s\n", err)
+			fmt.Fprintf(os.Stderr, "Unable to run zip cmd : %s\n", err)
 			return
 		}
 	}()

--- a/client/config.go
+++ b/client/config.go
@@ -20,6 +20,7 @@ import (
 type CliConfig struct {
 	Debug          bool
 	Quiet          bool
+	JSON           bool
 	URL            string
 	OneShot        bool
 	Removable      bool
@@ -258,6 +259,10 @@ func (config *CliConfig) UnmarshalArgs(opts docopt.Opts) (err error) {
 		config.Debug = true
 	}
 	if opts["--quiet"].(bool) {
+		config.Quiet = true
+	}
+	if opts["--json"].(bool) {
+		config.JSON = true
 		config.Quiet = true
 	}
 

--- a/client/crypto/age/age.go
+++ b/client/crypto/age/age.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 
 	"filippo.io/age"
@@ -55,7 +56,7 @@ func (ab *Backend) Configure(arguments map[string]any) (err error) {
 	// If no passphrase or recipient specified, generate a random passphrase
 	if ab.Config.Passphrase == "" && ab.Config.Recipient == "" {
 		ab.Config.Passphrase = generatePassphrase(32)
-		fmt.Printf("Passphrase : %s\n\n", ab.Config.Passphrase)
+		fmt.Fprintf(os.Stderr, "Passphrase : %s\n\n", ab.Config.Passphrase)
 	}
 
 	// Resolve recipient to age.Recipient objects
@@ -90,7 +91,7 @@ func resolveRecipients(recipient string) ([]age.Recipient, string, error) {
 			return nil, "", fmt.Errorf("empty GitHub username")
 		}
 		url := fmt.Sprintf("https://github.com/%s.keys", username)
-		fmt.Printf("Fetching SSH keys for @%s from %s\n", username, url)
+		fmt.Fprintf(os.Stderr, "Fetching SSH keys for @%s from %s\n", username, url)
 		recipients, err := fetchSSHKeys(url)
 		return recipients, "", err
 
@@ -103,7 +104,7 @@ func resolveRecipients(recipient string) ([]age.Recipient, string, error) {
 		if !strings.Contains(host, ":") {
 			host = host + ":22"
 		}
-		fmt.Printf("Scanning SSH host key from %s\n", host)
+		fmt.Fprintf(os.Stderr, "Scanning SSH host key from %s\n", host)
 		key, keyType, err := fetchHostKey(host)
 		if err != nil {
 			return nil, "", err
@@ -115,7 +116,7 @@ func resolveRecipients(recipient string) ([]age.Recipient, string, error) {
 		case ssh.KeyAlgoRSA:
 			keyPath = "/etc/ssh/ssh_host_rsa_key"
 		}
-		fmt.Printf("Found %s host key\n", keyType)
+		fmt.Fprintf(os.Stderr, "Found %s host key\n", keyType)
 		r, err := agessh.ParseRecipient(key)
 		if err != nil {
 			return nil, "", fmt.Errorf("invalid SSH host key: %s", err)
@@ -124,7 +125,7 @@ func resolveRecipients(recipient string) ([]age.Recipient, string, error) {
 
 	case strings.HasPrefix(recipient, "https://") || strings.HasPrefix(recipient, "http://"):
 		// Arbitrary URL containing SSH public keys
-		fmt.Printf("Fetching SSH keys from %s\n", recipient)
+		fmt.Fprintf(os.Stderr, "Fetching SSH keys from %s\n", recipient)
 		recipients, err := fetchSSHKeys(recipient)
 		return recipients, "", err
 
@@ -184,7 +185,7 @@ func fetchSSHKeys(url string) ([]age.Recipient, error) {
 		return nil, fmt.Errorf("no supported SSH keys found at %s (age supports ssh-rsa and ssh-ed25519)", url)
 	}
 
-	fmt.Printf("Found %d supported SSH key(s)\n", len(recipients))
+	fmt.Fprintf(os.Stderr, "Found %d supported SSH key(s)\n", len(recipients))
 
 	return recipients, nil
 }

--- a/client/crypto/openssl/openssl.go
+++ b/client/crypto/openssl/openssl.go
@@ -34,7 +34,7 @@ func (ob *Backend) Configure(arguments map[string]any) (err error) {
 	if arguments["--passphrase"] != nil && arguments["--passphrase"].(string) != "" {
 		ob.Config.Passphrase = arguments["--passphrase"].(string)
 		if ob.Config.Passphrase == "-" {
-			fmt.Printf("Please enter a passphrase : ")
+			fmt.Fprintf(os.Stderr, "Please enter a passphrase : ")
 			_, err = fmt.Scanln(&ob.Config.Passphrase)
 			if err != nil {
 				return err
@@ -42,7 +42,7 @@ func (ob *Backend) Configure(arguments map[string]any) (err error) {
 		}
 	} else {
 		ob.Config.Passphrase = common.GenerateRandomID(25)
-		fmt.Println("Passphrase : " + ob.Config.Passphrase)
+		fmt.Fprintln(os.Stderr, "Passphrase : "+ob.Config.Passphrase)
 	}
 	if arguments["--secure-options"] != nil && arguments["--secure-options"].(string) != "" {
 		ob.Config.Options = arguments["--secure-options"].(string)
@@ -55,19 +55,19 @@ func (ob *Backend) Configure(arguments map[string]any) (err error) {
 func (ob *Backend) Encrypt(in io.Reader) (out io.Reader, err error) {
 	passReader, passWriter, err := os.Pipe()
 	if err != nil {
-		fmt.Printf("Unable to make pipe : %s\n", err)
+		fmt.Fprintf(os.Stderr, "Unable to make pipe : %s\n", err)
 		os.Exit(1)
 		return
 	}
 	_, err = passWriter.Write([]byte(ob.Config.Passphrase))
 	if err != nil {
-		fmt.Printf("Unable to write to pipe : %s\n", err)
+		fmt.Fprintf(os.Stderr, "Unable to write to pipe : %s\n", err)
 		os.Exit(1)
 		return
 	}
 	err = passWriter.Close()
 	if err != nil {
-		fmt.Printf("Unable to close to pipe : %s\n", err)
+		fmt.Fprintf(os.Stderr, "Unable to close to pipe : %s\n", err)
 		os.Exit(1)
 		return
 	}

--- a/client/plik.go
+++ b/client/plik.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math/rand"
@@ -67,6 +68,7 @@ Options:
   --update                  Update client
   --login                   Authenticate CLI with the server (opens browser)
   --mcp                     Start as MCP (Model Context Protocol) server over stdio
+  -j, --json                Output upload metadata as JSON (implies --quiet)
   -q --quiet                Enable quiet mode
   -d --debug                Enable debug mode
   -v --version              Show client version
@@ -106,10 +108,10 @@ Options:
 	}
 
 	if config.Debug {
-		fmt.Println("Arguments : ")
-		utils.Dump(arguments)
-		fmt.Println("Configuration : ")
-		utils.Dump(config)
+		fmt.Fprintln(os.Stderr, "Arguments : ")
+		fmt.Fprintln(os.Stderr, utils.Sdump(arguments))
+		fmt.Fprintln(os.Stderr, "Configuration : ")
+		fmt.Fprintln(os.Stderr, utils.Sdump(config))
 	}
 
 	client := plik.NewClient(config.URL)
@@ -307,7 +309,7 @@ Options:
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Unable to get download command for file %s : %s\n", file.Name, err)
 			}
-			fmt.Println(cmd)
+			fmt.Fprintln(os.Stderr, cmd)
 		}
 		printf("\n")
 	}
@@ -323,6 +325,17 @@ Options:
 	if !config.Quiet && !config.Debug {
 		// Finalize the progress bar display
 		progress.stop()
+	}
+
+	// JSON output mode
+	if config.JSON {
+		data, err := json.MarshalIndent(upload.WithURL(), "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Unable to marshal upload metadata : %s\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(data))
+		os.Exit(0)
 	}
 
 	// Display download commands

--- a/client/test.sh
+++ b/client/test.sh
@@ -148,7 +148,7 @@ function uploadOpts {
         CURL_CMD="$CURL_CMD -u $UPLOAD_USER:$UPLOAD_PWD"
     fi
     CURL_CMD="$CURL_CMD $URL/upload/$UPLOAD_ID"
-    UPLOAD_OPTS=$( eval "$CURL_CMD" 2>/dev/null | python -m json.tool )
+    UPLOAD_OPTS=$( eval "$CURL_CMD" 2>/dev/null | python3 -m json.tool )
 }
 
 # Download files by running the output cmds
@@ -450,6 +450,38 @@ upload --quiet
 test $(cat $CLIENT_LOG | wc -l) -eq 1
 grep "$URL/file/.*/.*/FILE1" $CLIENT_LOG >/dev/null 2>/dev/null
 
+echo "OK"
+
+#---------------------------------------------
+
+echo -n " - json output : "
+
+before
+cp $SPECIMEN $TMPDIR/upload/FILE1
+upload --json
+# Verify output is valid JSON with expected fields
+cat $CLIENT_LOG | python3 -c "import json,sys; d=json.load(sys.stdin); assert 'url' in d; assert 'files' in d; assert len(d['files']) == 1" 2>/dev/null
+echo "OK"
+
+#---------------------------------------------
+
+echo -n " - json output multiple files : "
+
+before
+cp $SPECIMEN $TMPDIR/upload/FILE1
+cp $SPECIMEN $TMPDIR/upload/FILE2
+upload --json
+cat $CLIENT_LOG | python3 -c "import json,sys; d=json.load(sys.stdin); assert len(d['files']) == 2" 2>/dev/null
+echo "OK"
+
+#---------------------------------------------
+
+echo -n " - json output short flag : "
+
+before
+cp $SPECIMEN $TMPDIR/upload/FILE1
+upload -j
+cat $CLIENT_LOG | python3 -c "import json,sys; d=json.load(sys.stdin); assert 'url' in d" 2>/dev/null
 echo "OK"
 
 #---------------------------------------------

--- a/docs/features/cli-client.md
+++ b/docs/features/cli-client.md
@@ -70,14 +70,16 @@ Options:
   --archive-options OPTIONS [tar|zip] Additional command line options
   -s                        Encrypt upload using the default encryption parameters ( see ~/.plikrc )
   --not-secure              Do not encrypt upload files regardless of the ~/.plikrc configurations
-  --secure MODE             Encrypt upload files using the specified crypto backend : openssl|pgp
+  --secure MODE             Encrypt upload files using the specified crypto backend : openssl|pgp|age (default: age)
   --cipher CIPHER           [openssl] Openssl cipher to use ( see openssl help )
-  --passphrase PASSPHRASE   [openssl] Passphrase or '-' to be prompted for a passphrase
-  --recipient RECIPIENT     [pgp] Set recipient for pgp backend ( example : --recipient Bob )
+  --passphrase PASSPHRASE   [openssl|age] Passphrase or '-' to be prompted for a passphrase
+  --recipient RECIPIENT     [pgp|age] Set recipient ( pgp: name, age: @github_user, ssh://host, URL, ssh key, or age1... )
   --secure-options OPTIONS  [openssl|pgp] Additional command line options
   --insecure                (TLS) Do not verify the server's certificate chain and hostname
   --update                  Update client
   --login                   Authenticate with the Plik server via browser
+  --mcp                     Start as MCP (Model Context Protocol) server over stdio
+  -j --json                Output upload metadata as JSON (implies --quiet)
   -q --quiet                Enable quiet mode
   -d --debug                Enable debug mode
   -v --version              Show client version
@@ -89,7 +91,14 @@ Options:
 
 Upload a file:
 ```bash
-plik myfile.txt
+🪂 ➜  plik git:(master) ✗ plik README.md
+Upload successfully created at Sat, 21 Feb 2026 09:02:54 CET :
+    http://127.0.0.1:8080/#/?id=vDPmPEUqc5oCt31T
+
+README.md :  2.56 KiB / 2.56 KiB [=========================================] 100.00% 719.15 KiB/s 0s
+
+Commands :
+curl -s "http:/127.0.0.1:8080/file/vDPmPEUqc5oCt31T/UZzSdZ7zPgfRiTem/README.md" > 'README.md'
 ```
 
 Create an encrypted archive:


### PR DESCRIPTION
### What
Add `-j`/`--json` flag to the CLI client that outputs the `UploadWithURL` object as pretty-printed JSON to stdout. Implies `--quiet` mode. Configurable via `.plikrc`.

Also audit and redirect all informational/diagnostic prints to stderr for clean stdout separation.

### Changes
- **`config.go`** — add `JSON` field, parse `--json` flag
- **`plik.go`** — JSON output via `upload.WithURL()`, stderr for debug + streaming commands
- **`crypto/age/age.go`** — passphrase and recipient messages → stderr
- **`crypto/openssl/openssl.go`** — passphrase + pipe errors → stderr
- **`archive/tar/tar.go`**, **`archive/zip/zip.go`** — error messages → stderr
- **`test.sh`** — 3 integration tests (`--json`, `-j`, multiple files); `python` → `python3`
- **`client/ARCHITECTURE.md`** — document output modes + stderr convention
- **`docs/features/cli-client.md`** — `--json` flag + updated options

### Testing
- `go vet` / `go build` pass
- Unit tests pass (`crypto/age`)
- Integration tests added (require running server)

Closes #610