### PR TITLE
fix(webapp): improve E2EE passphrase editing UX

### DIFF
--- a/webapp/ARCHITECTURE.md
+++ b/webapp/ARCHITECTURE.md
@@ -722,7 +722,7 @@ Provides streaming encryption/decryption using the `age-encryption` npm package:
 ### Download Flow (E2EE)
 
 1. `DownloadView.onMounted()` reads passphrase from `pendingUploadStore` (same-session) or URL fragment `#key=` (shared link)
-2. If E2EE is set on the upload but no passphrase is available → modal prompt
+2. If E2EE is set on the upload but no passphrase is available → user enters it in the sidebar's editable passphrase input (two-way bound via `v-model:passphrase`)
 3. Passphrase is stripped from the URL after extraction (security measure)
 4. `decryptAndDownload()` fetches the encrypted file and decrypts in-browser via `fetchAndDecrypt()`
 5. For E2EE files, `FileRow` emits `decrypt-download` instead of using a direct download link
@@ -736,6 +736,6 @@ Provides streaming encryption/decryption using the `age-encryption` npm package:
 ### DownloadSidebar (E2EE)
 
 - **🔐 Encrypted badge**: Shown in upload info when `upload.e2ee` is truthy
-- **Passphrase display**: Shown in Share section with copy button (only when passphrase is available)
+- **Passphrase display**: Read-only display in Share section with edit (pencil) button and copy button, always shown for E2EE uploads. Edit button opens a modal to change the passphrase (uses `v-model:passphrase` for two-way binding with `DownloadView`)
 - **Include passphrase in link toggle**: Off by default — appends `#key=<passphrase>` to the share URL when enabled
 

--- a/webapp/src/components/DownloadSidebar.vue
+++ b/webapp/src/components/DownloadSidebar.vue
@@ -4,12 +4,13 @@ import { formatDate } from '../utils.js'
 import { getArchiveURL, getAdminURL } from '../api.js'
 import CopyButton from './CopyButton.vue'
 
+const passphrase = defineModel('passphrase', { type: String, default: null })
+
 const props = defineProps({
   upload: { type: Object, required: true },
-  passphrase: { type: String, default: null },
 })
 
-const emit = defineEmits(['delete-upload', 'add-files', 'show-qr'])
+const emit = defineEmits(['delete-upload', 'add-files', 'show-qr', 'edit-passphrase'])
 
 const expirationText = computed(() => {
   if (!props.upload.expireAt) return null
@@ -34,8 +35,8 @@ const adminUrl = computed(() => {
 const includePassphrase = ref(false)
 const shareUrl = computed(() => {
   let url = `${window.location.origin}${window.location.pathname}#/?id=${props.upload.id}`
-  if (includePassphrase.value && props.passphrase) {
-    url += `&key=${encodeURIComponent(props.passphrase)}`
+  if (includePassphrase.value && passphrase.value) {
+    url += `&key=${encodeURIComponent(passphrase.value)}`
   }
   return url
 })
@@ -66,7 +67,7 @@ const canAddFiles = computed(() => props.upload.admin && !props.upload.stream)
 </script>
 
 <template>
-  <aside class="w-full md:w-72 md:shrink-0 p-4 space-y-3 animate-slide-in">
+  <aside class="w-full md:w-80 md:shrink-0 p-4 space-y-3 animate-slide-in">
     <!-- Upload Info -->
     <div class="sidebar-section">
       <h3 class="text-xs font-semibold text-surface-400 uppercase tracking-wider mb-2">Upload Info</h3>
@@ -112,13 +113,22 @@ const canAddFiles = computed(() => props.upload.admin && !props.upload.stream)
       <h3 class="text-xs font-semibold text-surface-400 uppercase tracking-wider mb-2">Share</h3>
 
       <!-- Passphrase display (E2EE only) -->
-      <div v-if="upload.e2ee && passphrase" class="mb-3">
+      <div v-if="upload.e2ee" class="mb-3">
         <label class="text-xs text-surface-500 mb-1 block">Passphrase</label>
         <div class="flex items-center gap-2 p-2 rounded bg-surface-800/50 min-w-0 overflow-hidden">
-          <span class="text-xs text-accent-400 font-mono truncate flex-1">{{ passphrase }}</span>
-          <CopyButton :text="passphrase" size="sm" />
+          <span v-if="passphrase" class="text-xs text-accent-400 font-mono truncate flex-1">{{ passphrase }}</span>
+          <span v-else class="text-xs text-surface-500 italic flex-1">Not set</span>
+          <button class="text-surface-400 hover:text-accent-400 transition-colors shrink-0"
+                  title="Edit passphrase"
+                  @click="emit('edit-passphrase')">
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                    d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+            </svg>
+          </button>
+          <CopyButton v-if="passphrase" :text="passphrase" size="sm" />
         </div>
-        <label class="flex items-center justify-between py-1.5 mt-2 cursor-pointer group">
+        <label v-if="passphrase" class="flex items-center justify-between py-1.5 mt-2 cursor-pointer group">
           <span class="text-xs text-surface-400 group-hover:text-surface-200 transition-colors">Include passphrase in link</span>
           <button type="button"
                   class="toggle-switch scale-75"

--- a/webapp/src/components/UploadSidebar.vue
+++ b/webapp/src/components/UploadSidebar.vue
@@ -117,7 +117,7 @@ const hasAnySettings = computed(() =>
 </script>
 
 <template>
-  <aside v-if="hasAnySettings" class="w-full md:w-72 md:shrink-0 p-4 space-y-3 animate-slide-in">
+  <aside v-if="hasAnySettings" class="w-full md:w-80 md:shrink-0 p-4 space-y-3 animate-slide-in">
     <!-- Upload Settings -->
     <div class="sidebar-section">
       <h3 class="text-xs font-semibold text-surface-400 uppercase tracking-wider mb-2">Upload Settings</h3>

--- a/webapp/src/views/DownloadView.vue
+++ b/webapp/src/views/DownloadView.vue
@@ -391,7 +391,7 @@ function openQrFile(file) {
 // E2EE decrypt-and-download handler
 async function decryptAndDownload(file) {
   if (!e2eePassphrase.value) {
-    showPassphraseModal.value = true
+    openPassphraseModal()
     return
   }
 
@@ -410,6 +410,11 @@ async function decryptAndDownload(file) {
   } finally {
     isDecrypting.value = false
   }
+}
+
+function openPassphraseModal() {
+  passphraseInput.value = e2eePassphrase.value || ''
+  showPassphraseModal.value = true
 }
 
 function submitPassphrase() {
@@ -455,7 +460,7 @@ onMounted(async () => {
 
   // If this is an E2EE upload and we don't have the passphrase, prompt the user
   if (upload.value?.e2ee && !e2eePassphrase.value) {
-    showPassphraseModal.value = true
+    openPassphraseModal()
   }
 })
 
@@ -503,13 +508,14 @@ watch(activeFiles, (files) => {
       <DownloadSidebar
         v-if="upload"
         :upload="{ ...upload, admin: isAdmin }"
-        :passphrase="e2eePassphrase"
+        v-model:passphrase="e2eePassphrase"
+        @edit-passphrase="openPassphraseModal"
         @delete-upload="deleteUpload"
         @add-files="triggerAddFiles"
         @show-qr="openQrUpload" />
 
       <!-- Loading placeholder sidebar -->
-      <aside v-else class="w-full md:w-72 md:shrink-0 p-4">
+      <aside v-else class="w-full md:w-80 md:shrink-0 p-4">
         <div class="sidebar-section animate-pulse">
           <div class="h-4 bg-surface-700 rounded w-1/2 mb-3" />
           <div class="h-8 bg-surface-700 rounded mb-2" />
@@ -573,13 +579,8 @@ watch(activeFiles, (files) => {
             </svg>
             <div>
               <span class="text-sm text-accent-400 font-medium">End-to-End Encrypted</span>
-              <p class="text-xs text-surface-400 mt-0.5">
-                {{ e2eePassphrase ? 'Passphrase available — files will be decrypted in your browser' : 'Enter passphrase to decrypt files' }}
-              </p>
+              <p class="text-xs text-surface-400 mt-0.5">Files will be decrypted in your browser</p>
             </div>
-            <button v-if="!e2eePassphrase"
-                    class="ml-auto text-xs text-accent-400 hover:text-accent-300 transition-colors"
-                    @click="showPassphraseModal = true">Enter passphrase</button>
           </div>
 
           <!-- Decrypting Spinner -->


### PR DESCRIPTION
### What
Improve the E2EE passphrase handling UX in the download view.

### Why
Previously, if a wrong passphrase was entered for an E2EE upload, the passphrase field became non-editable, preventing correction.

### Changes
- **DownloadSidebar**: Passphrase section always visible for E2EE uploads with read-only display, edit (pencil) button, and copy button. Uses `defineModel` for `v-model:passphrase` two-way binding
- **DownloadView**: New `openPassphraseModal()` helper centralizes modal logic. Modal auto-opens on mount when passphrase is missing. Edit button in sidebar opens pre-filled modal. Simplified E2EE indicator text
- **UploadSidebar**: Width aligned to `w-80` to match download sidebar
- **ARCHITECTURE.md**: Updated to reflect new passphrase editing flow

### Testing
- Frontend build passes (`make frontend`)
- Manual verification of passphrase entry, editing, and correction flows