### PR TITLE
fix(deb): handle missing systemd and keep gh-pages history-free

### DIFF
--- a/.agent/workflows/cut-release.md
+++ b/.agent/workflows/cut-release.md
@@ -289,7 +289,31 @@ After the release is published:
   ```bash
   curl -s https://root-gg.github.io/plik/index.yaml | grep <VERSION>
   ```
-- [ ] **Verify GitHub release page** — check that the changelog and release artifacts (archives + Helm chart `.tgz`) are attached
+- [ ] **Verify Debian packages** — boot a Debian container and test APT repo setup + package install:
+  ```bash
+  docker run --rm debian:bookworm bash -c '
+    set -e
+    apt-get update && apt-get install -y curl gnupg
+    curl -fsSL https://root-gg.github.io/plik/apt/gpg.key | gpg --dearmor -o /etc/apt/keyrings/plik.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/plik.gpg] https://root-gg.github.io/plik/apt stable main" > /etc/apt/sources.list.d/plik.list
+    apt-get update
+    apt-get install -y plik-server plik-client
+    echo "--- Verify versions ---"
+    plik --version
+    plik-server --version
+    echo "--- Verify installed files ---"
+    dpkg -L plik-server | head -20
+    dpkg -L plik-client
+    echo "--- Verify systemd unit ---"
+    test -f /lib/systemd/system/plik-server.service && echo "systemd unit: OK" || echo "systemd unit: MISSING"
+    echo "--- All checks passed ---"
+  '
+  ```
+  Verify:
+  - Both packages install without errors
+  - `plik --version` and `plik-server --version` output `<VERSION>`
+  - The systemd service unit is installed
+- [ ] **Verify GitHub release page** — check that the changelog and release artifacts (archives + Helm chart `.tgz` + `.deb` files) are attached
 
 ## Important Notes
 

--- a/releaser/apt_release.sh
+++ b/releaser/apt_release.sh
@@ -142,14 +142,28 @@ else
   echo " Warning: no GPG key provided, skipping signing"
 fi
 
-# Fetch gh-pages branch
-git fetch "$GIT_REMOTE" gh-pages
+# Fetch gh-pages branch (may not exist yet on first run)
+git fetch "$GIT_REMOTE" gh-pages 2>/dev/null || true
 
-# Prepare a temp worktree with gh-pages content
+# Prepare a temp worktree
 WORKTREE=$(mktemp -d)
 trap "rm -rf $WORKTREE" EXIT
 
-git worktree add --detach "$WORKTREE" "$GIT_REMOTE/gh-pages"
+if git rev-parse --verify "$GIT_REMOTE/gh-pages" >/dev/null 2>&1; then
+  # Clone existing gh-pages content so we keep previous packages in the pool
+  git worktree add --detach "$WORKTREE" "$GIT_REMOTE/gh-pages"
+  # Convert to an orphan branch (discard history, keep files)
+  cd "$WORKTREE"
+  git checkout --orphan gh-pages-orphan
+  cd -
+else
+  # First run: create a fresh worktree with an orphan branch
+  git worktree add --detach "$WORKTREE" HEAD
+  cd "$WORKTREE"
+  git checkout --orphan gh-pages-orphan
+  git rm -rf . >/dev/null 2>&1 || true
+  cd -
+fi
 
 # Create APT repo directory structure
 APT_DIR="$WORKTREE/apt"
@@ -229,14 +243,14 @@ if [[ "$DRY_RUN" == "true" ]]; then
   exit 0
 fi
 
-# Commit and push to gh-pages
+# Commit and force-push to gh-pages (single orphan commit, no history)
 cd "$WORKTREE"
 git add apt/
 git commit -m "Update APT repository for $TAG"
-git push "$GIT_REMOTE" HEAD:gh-pages
+git push --force "$GIT_REMOTE" HEAD:gh-pages
 cd -
 
-git worktree remove "$WORKTREE"
+git worktree remove "$WORKTREE" --force
 
 # Remove .deb files from releases/ — they are now in the APT repository
 rm -f releases/*.deb

--- a/releaser/scripts/server-postinstall.sh
+++ b/releaser/scripts/server-postinstall.sh
@@ -29,5 +29,7 @@ if grep -q 'WebappDirectory.*= "../webapp/dist"' "$CFG" 2>/dev/null; then
 fi
 
 # Reload systemd and enable (but don't start) the service
-systemctl daemon-reload
-systemctl enable plikd.service || true
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl daemon-reload
+  systemctl enable plikd.service || true
+fi


### PR DESCRIPTION
## Changes

### Guard systemctl in postinstall script
The `server-postinstall.sh` script now checks for `systemctl` availability before calling it, so `.deb` packages install cleanly in Docker containers and chroots without systemd.

### Orphan commits for gh-pages
`apt_release.sh` now force-pushes an orphan commit to `gh-pages` on every update, so the branch always contains a single commit. This prevents history from growing with large `.deb` binaries.

### Workflow update
Added a Debian package verification step to the post-release checklist — boots a Debian container, sets up the APT repo, and installs both packages end-to-end.