### PR TITLE
ci(docker): pass VERSION to Docker build system

### DIFF
--- a/.github/workflows/docker-build-pr.yaml
+++ b/.github/workflows/docker-build-pr.yaml
@@ -71,6 +71,7 @@ jobs:
       - name: Build and push
         env:
           TAG: pr-${{ github.event.issue.number }}
+          VERSION: pr-${{ github.event.issue.number }}
           RELEASE: "false"
           PUSH_TO_DOCKER_HUB: "true"
         run: make release-and-push-to-docker-hub

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ WORKDIR /go/src/github.com/root-gg/plik
 ARG CLIENT_TARGETS=""
 ENV CLIENT_TARGETS=$CLIENT_TARGETS
 
+ARG VERSION=""
+ENV VERSION=$VERSION
+
 # Add the source code ( see .dockerignore )
 COPY . .
 
@@ -47,6 +50,9 @@ ENV TARGETOS=$TARGETOS
 ENV TARGETARCH=$TARGETARCH
 ENV TARGETVARIANT=$TARGETVARIANT
 ENV CC=$CC
+
+ARG VERSION=""
+ENV VERSION=$VERSION
 
 # Add the source code ( see .dockerignore )
 COPY . .

--- a/releaser/release.sh
+++ b/releaser/release.sh
@@ -29,6 +29,10 @@ DOCKER_IMAGE=${DOCKER_IMAGE:-rootgg/plik}
 DOCKER_TAG=${TAG:-dev}
 TARGETS=${TARGETS:-linux/amd64,linux/i386,linux/arm64,linux/arm}
 
+if [[ -n "$VERSION" ]]; then
+  BUILD_ARGS="$BUILD_ARGS --build-arg VERSION=$VERSION"
+fi
+
 if [[ -n "$CLIENT_TARGETS" ]]; then
   BUILD_ARGS="$BUILD_ARGS --build-arg CLIENT_TARGETS=$CLIENT_TARGETS"
 fi


### PR DESCRIPTION
### What
Pass the `VERSION` environment variable into Docker builds so the version string embedded in the plik binary matches the Docker image tag.

### Why
When the `docker-build-pr` workflow builds an image tagged `pr-<N>`, the binary inside reports whatever `git describe --tags` returns instead of the PR tag. This makes it hard to identify which build is running.

### Changes
- **`releaser/release.sh`** — forward `VERSION` as `--build-arg` to all `docker buildx build` calls
- **`Dockerfile`** — accept `VERSION` as `ARG`/`ENV` in the `plik-client-builder` and `plik-builder` stages
- **`.github/workflows/docker-build-pr.yaml`** — set `VERSION=pr-${{ github.event.issue.number }}` alongside `TAG`