### PR TITLE
fix(docker): improve PR build version string

### DIFF
--- a/.github/workflows/docker-build-pr.yaml
+++ b/.github/workflows/docker-build-pr.yaml
@@ -68,10 +68,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Compute version
+        id: version
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0)
+          SHORT_COMMIT=$(git rev-parse --short HEAD)
+          VERSION="${LATEST_TAG}:pr-${{ github.event.issue.number }}:${SHORT_COMMIT}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         env:
           TAG: pr-${{ github.event.issue.number }}
-          VERSION: pr-${{ github.event.issue.number }}
+          VERSION: ${{ steps.version.outputs.version }}
           RELEASE: "false"
           PUSH_TO_DOCKER_HUB: "true"
         run: make release-and-push-to-docker-hub

--- a/server/common/version.go
+++ b/server/common/version.go
@@ -96,7 +96,7 @@ func (bi *BuildInfo) Sanitize() {
 
 func (bi *BuildInfo) String() string {
 
-	v := fmt.Sprintf("v%s", bi.Version)
+	v := bi.Version
 
 	if bi.GitShortRevision != "" {
 		v += fmt.Sprintf(" built from git rev %s", bi.GitShortRevision)

--- a/server/common/version_test.go
+++ b/server/common/version_test.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 	"testing"
@@ -50,5 +49,5 @@ func TestGetBuildInfoStringSanitize(t *testing.T) {
 	buildInfo := GetBuildInfo()
 	buildInfo.Sanitize()
 	v := buildInfo.String()
-	require.Equal(t, fmt.Sprintf("v%s", buildInfo.Version), v, "invalid build string")
+	require.Equal(t, buildInfo.Version, v, "invalid build string")
 }


### PR DESCRIPTION
### What
- Remove the hardcoded `v` prefix from `BuildInfo.String()` — non-semver versions like `pr-555` no longer display as `vpr-555`
- Compute a richer version for PR Docker builds: `<latest-tag>:pr-<number>:<short-commit>` (e.g. `1.4-RC4:pr-555:6fde4f`)

### Why
PR Docker builds were showing `vpr-555` as the version, which is confusing. The new format gives full traceability: base tag, PR number, and exact commit.

### Changes
- **`server/common/version.go`** — Removed `v` prefix from `String()`
- **`server/common/version_test.go`** — Updated test, removed unused `fmt` import
- **`.github/workflows/docker-build-pr.yaml`** — New "Compute version" step that builds `<tag>:pr-N:<commit>`

### Testing
- `make lint` ✅
- `go test ./server/common/` ✅ (all tests pass)