### PR TITLE
fix(docker): use dashes instead of colons in PR build version string

### DIFF
--- a/.github/workflows/docker-build-pr.yaml
+++ b/.github/workflows/docker-build-pr.yaml
@@ -73,7 +73,7 @@ jobs:
         run: |
           LATEST_TAG=$(git describe --tags --abbrev=0)
           SHORT_COMMIT=$(git rev-parse --short HEAD)
-          VERSION="${LATEST_TAG}:pr-${{ github.event.issue.number }}:${SHORT_COMMIT}"
+          VERSION="${LATEST_TAG}-pr-${{ github.event.issue.number }}-${SHORT_COMMIT}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push


### PR DESCRIPTION
### What
Replace colons with dashes in the `VERSION` string computed by the PR Docker build workflow.

### Why
Colons in the archive filename (e.g. `plik-server-1.4-RC4:pr-636:58d5275c-linux-arm.tar.gz`) cause `tar` to interpret the filename as a remote host path (`host:path`), failing with `"Cannot connect to plik-server-1.4-RC4: resolve failed"`.

### Changes
- `.github/workflows/docker-build-pr.yaml`: change VERSION separator from `:` to `-`

### Testing
- YAML validated
- Verified the resulting filename `plik-server-1.4-RC4-pr-636-58d5275c-linux-arm.tar.gz` contains no special characters