### PR TITLE
docs(helm): add helm-docs annotations and generate chart README

### DIFF
--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -29,6 +29,7 @@ Runs on every push and pull request. Steps:
 2. Go tests (`make test`)
 3. Frontend tests (`make test-frontend`) — vitest unit tests for the Vue webapp
 4. Docs build (`make docs`) — verifies VitePress builds without errors
+5. Helm docs check (`make helm-docs`) — regenerates chart README and fails if there are uncommitted changes
 
 ### `pages.yml` — GitHub Pages (Docs)
 
@@ -84,7 +85,7 @@ helm repo add plik https://root-gg.github.io/plik
 helm install plik plik/plik
 ```
 
-The chart source lives in `charts/plik/`. See the chart's `values.yaml` for all configuration options.
+The chart source lives in `charts/plik/`. See the chart's [README](https://github.com/root-gg/plik/blob/master/charts/plik/README.md) for all configuration options.
 
 ## APT Repository Release Flow
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -155,3 +155,27 @@ jobs:
 
     - name: Build docs
       run: make docs
+
+  helm-docs:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Install helm-docs
+      run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
+
+    - name: Run helm-docs
+      run: make helm-docs
+
+    - name: Check for uncommitted changes
+      run: |
+        git diff --exit-code || { echo "::error::Uncommitted changes detected after running helm-docs. Run 'make helm-docs' and commit the result."; git status; exit 1; }
+        UNTRACKED=$(git ls-files --others --exclude-standard)
+        if [ -n "$UNTRACKED" ]; then echo "::error::Untracked files detected after running helm-docs."; git status; exit 1; fi

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -312,9 +312,10 @@ Arrays are overridden, maps are merged.
 ### Helm Chart Sync
 
 The Helm chart (`charts/plik/`) mirrors the configuration model. When adding or modifying config fields in `server/common/config.go` or `server/plikd.cfg`, **always update**:
-- `charts/plik/values.yaml` — add the field under `plikd:` with its default value
+- `charts/plik/values.yaml` — add the field under `plikd:` with its default value and a `# --` helm-docs annotation
 - `charts/plik/templates/configmap.yaml` — add the explicit key to the template
 - `charts/plik/templates/secret.yaml` — if the field is sensitive, add env var injection (`PLIKD_` prefix)
+- Run `make helm-docs` to regenerate `charts/plik/README.md` (CI will fail if this is forgotten)
 
 #### Helm Chart Persistence
 

--- a/Makefile
+++ b/Makefile
@@ -176,9 +176,16 @@ release-and-push-to-docker-hub:
 	@PUSH_TO_DOCKER_HUB=true releaser/release.sh
 
 ###
+# Regenerate Helm chart README from values.yaml annotations
+# Requires: helm-docs (go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest)
+###
+helm-docs:
+	@helm-docs --chart-search-root ./charts
+
+###
 # Package Helm chart locally (auto-detects version from git tags)
 ###
-helm:
+helm: helm-docs
 	@DRY_RUN=true releaser/helm_release.sh $(VERSION)
 
 ###
@@ -274,4 +281,4 @@ deb-publish:
 # by make, we must declare these targets as phony to avoid :
 # "make: `client' is up to date" cases at compile time
 ###
-.PHONY: client clients server release helm helm-install deb deb-publish docs test-backend test-frontend test-frontend-e2e
+.PHONY: client clients server release helm helm-docs helm-install deb deb-publish docs test-backend test-frontend test-frontend-e2e

--- a/charts/plik/ARCHITECTURE.md
+++ b/charts/plik/ARCHITECTURE.md
@@ -9,7 +9,9 @@
 ```
 charts/plik/
 ├── Chart.yaml                  ← Chart metadata (version set at release time via __VERSION__)
-├── values.yaml                 ← All user-configurable values
+├── values.yaml                 ← All user-configurable values (annotated for helm-docs)
+├── README.md.gotmpl            ← helm-docs template for generating README.md
+├── README.md                   ← Auto-generated values reference (do not edit manually)
 ├── CHANGELOG.md                ← Keep-a-Changelog (update [Unreleased] before each release)
 ├── ARCHITECTURE.md             ← this file
 └── templates/
@@ -19,13 +21,8 @@ charts/plik/
     ├── deployment.yaml         ← Deployment or StatefulSet (controlled by .Values.kind)
     ├── service.yaml            ← ClusterIP service on port 8080
     ├── ingress.yaml            ← Optional Ingress resource
-    ├── hpa.yaml                ← Optional HorizontalPodAutoscaler
-    ├── serviceaccount.yaml     ← Optional ServiceAccount
-    ├── pvc.yaml                ← PVC for file data (when persistence.enabled + kind=Deployment)
-    ├── pvc-db.yaml             ← PVC for SQLite DB (when dbPersistence.enabled + kind=Deployment)
-    ├── NOTES.txt               ← Post-install instructions
-    └── tests/
-        └── test-connection.yaml
+    ├── pvc.yaml                ← PVC for file/db data (when persistence/dbPersistence enabled)
+    └── NOTES.txt               ← Post-install instructions
 ```
 
 ---

--- a/charts/plik/README.md
+++ b/charts/plik/README.md
@@ -1,0 +1,176 @@
+# plik
+
+A Helm chart for Plik, a scalable & friendly temporary file upload system.
+
+![Version: __VERSION__](https://img.shields.io/badge/Version-__VERSION__-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: __VERSION__](https://img.shields.io/badge/AppVersion-__VERSION__-informational?style=flat-square)
+
+## Installation
+
+### From Helm repository (recommended)
+
+```bash
+helm repo add plik https://root-gg.github.io/plik
+helm repo update
+helm install plik plik/plik
+```
+
+### From source
+
+```bash
+git clone https://github.com/root-gg/plik.git
+cd plik
+make helm-install
+```
+
+## Quick Start
+
+Minimal install with default settings (in-memory storage, no authentication):
+
+```bash
+helm repo add plik https://root-gg.github.io/plik
+helm install plik plik/plik
+```
+
+With persistence and ingress:
+
+```yaml
+# custom-values.yaml
+kind: StatefulSet
+
+persistence:
+  enabled: true
+  size: 50Gi
+
+dbPersistence:
+  enabled: true
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: plik.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: plik-tls
+      hosts:
+        - plik.example.com
+
+plikd:
+  FeatureAuthentication: "forced"
+  MaxFileSizeStr: "5GB"
+  DefaultTTLStr: "7d"
+  MaxTTLStr: "30d"
+```
+
+```bash
+helm install plik plik/plik -f custom-values.yaml
+```
+
+## Architecture
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for design decisions around config vs. secrets separation, persistence, and workload kind.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for pod scheduling |
+| autoscaling.enabled | bool | `false` | Enable Horizontal Pod Autoscaler |
+| autoscaling.maxReplicas | int | `100` | Maximum number of replicas |
+| autoscaling.minReplicas | int | `1` | Minimum number of replicas |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization percentage |
+| dbPersistence.accessModes | list | `["ReadWriteOnce"]` | PVC access modes |
+| dbPersistence.enabled | bool | `false` | Enable persistent storage for the SQLite database |
+| dbPersistence.path | string | `"/home/plik/server/db"` | Mount path for the database inside the container |
+| dbPersistence.size | string | `"1Gi"` | PVC storage size |
+| fullnameOverride | string | `""` | Override the full release name |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| image.repository | string | `"rootgg/plik"` | Docker image repository |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
+| imagePullSecrets | list | `[]` | Docker registry pull secrets |
+| ingress.annotations | object | `{}` | Additional ingress annotations |
+| ingress.className | string | `""` | Ingress class name |
+| ingress.enabled | bool | `false` | Enable Ingress resource |
+| ingress.hosts | list | `[{"host":"chart-example.local","paths":[{"path":"/","pathType":"ImplementationSpecific"}]}]` | Ingress host rules |
+| ingress.tls | list | `[]` | Ingress TLS configuration |
+| kind | string | `"Deployment"` | Workload kind: `Deployment` or `StatefulSet`. Use StatefulSet if you are using the `file` backend with a PersistentVolume. |
+| nameOverride | string | `""` | Override the chart name |
+| nodeSelector | object | `{}` | Node selector for pod scheduling |
+| persistence.accessModes | list | `["ReadWriteOnce"]` | PVC access modes |
+| persistence.enabled | bool | `false` | Enable persistent storage for uploaded files |
+| persistence.path | string | `"/home/plik/server/files"` | Mount path for file storage inside the container |
+| persistence.size | string | `"10Gi"` | PVC storage size |
+| plikd | object | see sub-values | Plik server configuration. Values are rendered into the `plikd.cfg` config file. See [server configuration reference](https://github.com/root-gg/plik/tree/master/server/plikd.cfg) for all options. |
+| plikd.AbuseContact | string | `""` | Abuse contact email displayed in the footer |
+| plikd.ChangelogDirectory | string | `"../changelog"` | Path to the changelog directory |
+| plikd.ClientsDirectory | string | `"../clients"` | Path to the pre-built CLI clients directory |
+| plikd.DataBackend | string | `"file"` | Data backend type (`file`, `gcs`, `s3`, `swift`) |
+| plikd.DataBackendConfig | object | `{"Directory":"files"}` | Non-sensitive data backend configuration. Keys depend on the backend type. See [data backends](https://github.com/root-gg/plik#data-backends). |
+| plikd.Debug | bool | `false` | Enable debug mode |
+| plikd.DebugRequests | bool | `false` | Log every HTTP request |
+| plikd.DefaultTTLStr | string | `"30d"` | Default upload TTL (e.g. `30d`, `24h`) |
+| plikd.DownloadDomain | string | `""` | Custom download domain |
+| plikd.DownloadDomainAlias | list | `[]` | Additional download domain aliases |
+| plikd.EnhancedWebSecurity | bool | `false` | Enable enhanced web security headers (CSP, X-Frame-Options, etc.) |
+| plikd.FeatureAuthentication | string | `"disabled"` | Enable user authentication (`enabled`, `disabled`, `forced`) |
+| plikd.FeatureClients | string | `"enabled"` | Enable pre-built CLI clients download page |
+| plikd.FeatureComments | string | `"enabled"` | Enable upload comments |
+| plikd.FeatureDeleteAccount | string | `"enabled"` | Allow users to delete their account |
+| plikd.FeatureExtendTTL | string | `"disabled"` | Allow users to extend an existing TTL |
+| plikd.FeatureGithub | string | `"enabled"` | Show GitHub link in the footer |
+| plikd.FeatureLocalLogin | string | `"enabled"` | Enable local login |
+| plikd.FeatureOneShot | string | `"enabled"` | Enable one-shot downloads |
+| plikd.FeaturePassword | string | `"enabled"` | Enable password-protected uploads |
+| plikd.FeatureRemovable | string | `"enabled"` | Enable removable uploads |
+| plikd.FeatureSetTTL | string | `"enabled"` | Allow users to set a custom TTL |
+| plikd.FeatureStream | string | `"enabled"` | Enable streaming uploads |
+| plikd.FeatureText | string | `"enabled"` | Enable plain-text paste mode |
+| plikd.GoogleApiClientID | string | `""` | Google OAuth2 client ID |
+| plikd.GoogleValidDomains | list | `[]` | Allowed Google domains (empty = allow all) |
+| plikd.ListenAddress | string | `"0.0.0.0"` | HTTP listen address |
+| plikd.ListenPort | int | `8080` | HTTP listen port |
+| plikd.LogLevel | string | `"INFO"` | Log level (`DEBUG`, `INFO`, `WARNING`, `CRITICAL`) |
+| plikd.MaxFilePerUpload | int | `1000` | Maximum number of files per upload |
+| plikd.MaxFileSizeStr | string | `"10GB"` | Maximum file size per upload (e.g. `10GB`, `unlimited`) |
+| plikd.MaxTTLStr | string | `"30d"` | Maximum upload TTL |
+| plikd.MaxUserSizeStr | string | `"unlimited"` | Maximum total size per user (e.g. `10GB`, `unlimited`) |
+| plikd.MetadataBackendConfig | object | `{"ConnectionString":"/home/plik/server/db/plik.db","Debug":false,"Driver":"sqlite3"}` | Metadata backend configuration (database driver, connection string) |
+| plikd.MetricsAddress | string | `"0.0.0.0"` | Prometheus metrics listen address |
+| plikd.MetricsPort | int | `0` | Prometheus metrics port (0 = disabled) |
+| plikd.NoWebInterface | bool | `false` | Disable the web interface |
+| plikd.OIDCClientID | string | `""` | OpenID Connect client ID |
+| plikd.OIDCProviderName | string | `"OpenID"` | Display name for the OIDC provider |
+| plikd.OIDCProviderURL | string | `""` | OpenID Connect provider discovery URL |
+| plikd.OIDCRequireVerifiedEmail | bool | `false` | Require verified email from OIDC provider |
+| plikd.OIDCValidDomains | list | `[]` | Allowed OIDC email domains (empty = allow all) |
+| plikd.OvhApiEndpoint | string | `""` | OVH API endpoint (e.g. `ovh-eu`, `ovh-ca`) |
+| plikd.Path | string | `""` | URL path prefix (e.g. `/plik`) |
+| plikd.SessionTimeout | string | `"365d"` | User session timeout (e.g. `365d`, `24h`) |
+| plikd.SourceIpHeader | string | `""` | HTTP header to use for source IP (e.g. `X-Forwarded-For`) |
+| plikd.SslCert | string | `"plik.crt"` | Path to TLS certificate |
+| plikd.SslEnabled | bool | `false` | Enable HTTPS |
+| plikd.SslKey | string | `"plik.key"` | Path to TLS private key |
+| plikd.TlsVersion | string | `"tlsv10"` | Minimum TLS version (`tlsv10`, `tlsv11`, `tlsv12`, `tlsv13`) |
+| plikd.UploadWhitelist | list | `[]` | IP whitelist for uploads (empty = allow all) |
+| plikd.WebappDirectory | string | `"../webapp/dist"` | Path to the webapp distribution directory |
+| podAnnotations | object | `{}` | Additional pod annotations |
+| podSecurityContext | object | `{}` | Pod-level security context |
+| replicaCount | int | `1` | Number of pod replicas |
+| resources | object | `{}` | CPU/memory resource requests and limits |
+| secrets.dataBackend | object | `{}` | Sensitive data backend config (merged with `plikd.DataBackendConfig` at runtime). Injected as `PLIKD_DATA_BACKEND_CONFIG` JSON. |
+| secrets.existingSecret | string | `""` | Use an existing Kubernetes Secret instead of creating one. The Secret must contain the relevant env var keys. |
+| secrets.googleApiSecret | string | `""` | Google OAuth2 client secret (injected as `PLIKD_GOOGLE_API_SECRET`) |
+| secrets.metadataBackend | object | `{}` | Sensitive metadata backend config (e.g. database password). Injected as `PLIKD_METADATA_BACKEND_CONFIG` JSON. |
+| secrets.oidcClientSecret | string | `""` | OIDC client secret (injected as `PLIKD_OIDC_CLIENT_SECRET`) |
+| secrets.ovhApiKey | string | `""` | OVH API key (injected as `PLIKD_OVH_API_KEY`) |
+| secrets.ovhApiSecret | string | `""` | OVH API secret (injected as `PLIKD_OVH_API_SECRET`) |
+| securityContext | object | `{}` | Container-level security context |
+| service.annotations | object | `{}` | Additional service annotations |
+| service.port | int | `8080` | Service port |
+| service.type | string | `"ClusterIP"` | Kubernetes Service type |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| tolerations | list | `[]` | Tolerations for pod scheduling |

--- a/charts/plik/README.md.gotmpl
+++ b/charts/plik/README.md.gotmpl
@@ -1,0 +1,75 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+## Installation
+
+### From Helm repository (recommended)
+
+```bash
+helm repo add plik https://root-gg.github.io/plik
+helm repo update
+helm install plik plik/plik
+```
+
+### From source
+
+```bash
+git clone https://github.com/root-gg/plik.git
+cd plik
+make helm-install
+```
+
+## Quick Start
+
+Minimal install with default settings (in-memory storage, no authentication):
+
+```bash
+helm repo add plik https://root-gg.github.io/plik
+helm install plik plik/plik
+```
+
+With persistence and ingress:
+
+```yaml
+# custom-values.yaml
+kind: StatefulSet
+
+persistence:
+  enabled: true
+  size: 50Gi
+
+dbPersistence:
+  enabled: true
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: plik.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: plik-tls
+      hosts:
+        - plik.example.com
+
+plikd:
+  FeatureAuthentication: "forced"
+  MaxFileSizeStr: "5GB"
+  DefaultTTLStr: "7d"
+  MaxTTLStr: "30d"
+```
+
+```bash
+helm install plik plik/plik -f custom-values.yaml
+```
+
+## Architecture
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for design decisions around config vs. secrets separation, persistence, and workload kind.
+
+{{ template "chart.valuesSection" . }}

--- a/charts/plik/values.yaml
+++ b/charts/plik/values.yaml
@@ -2,32 +2,41 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# -- Number of pod replicas
 replicaCount: 1
 
 image:
+  # -- Docker image repository
   repository: rootgg/plik
+  # -- Image pull policy
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
+  # -- Overrides the image tag whose default is the chart appVersion
   tag: ""
 
+# -- Docker registry pull secrets
 imagePullSecrets: []
+# -- Override the chart name
 nameOverride: ""
+# -- Override the full release name
 fullnameOverride: ""
 
 serviceAccount:
-  # Specifies whether a service account should be created
+  # -- Specifies whether a service account should be created
   create: false
-  # Annotations to add to the service account
+  # -- Annotations to add to the service account
   annotations: {}
-  # The name of the service account to use.
+  # -- The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# -- Additional pod annotations
 podAnnotations: {}
 
+# -- Pod-level security context
 podSecurityContext: {}
   # fsGroup: 2000
 
+# -- Container-level security context
 securityContext: {}
   # capabilities:
   #   drop:
@@ -37,26 +46,35 @@ securityContext: {}
   # runAsUser: 1000
 
 service:
+  # -- Kubernetes Service type
   type: ClusterIP
+  # -- Service port
   port: 8080
+  # -- Additional service annotations
   annotations: {}
 
 ingress:
+  # -- Enable Ingress resource
   enabled: false
+  # -- Ingress class name
   className: ""
+  # -- Additional ingress annotations
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  # -- Ingress host rules
   hosts:
     - host: chart-example.local
       paths:
         - path: /
           pathType: ImplementationSpecific
+  # -- Ingress TLS configuration
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
 
+# -- CPU/memory resource requests and limits
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
@@ -70,106 +88,174 @@ resources: {}
   #   memory: 128Mi
 
 autoscaling:
+  # -- Enable Horizontal Pod Autoscaler
   enabled: false
+  # -- Minimum number of replicas
   minReplicas: 1
+  # -- Maximum number of replicas
   maxReplicas: 100
+  # -- Target CPU utilization percentage
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+# -- Node selector for pod scheduling
 nodeSelector: {}
 
+# -- Tolerations for pod scheduling
 tolerations: []
 
+# -- Affinity rules for pod scheduling
 affinity: {}
 
 # Plik specific configuration
 # This section mirrors the plikd.cfg configuration file
 
-# Deployment Strategy
-# Can be 'Deployment' or 'StatefulSet'.
-# Use StatefulSet if you are using 'file' backend with a PersistentVolume.
+# -- Workload kind: `Deployment` or `StatefulSet`.
+# Use StatefulSet if you are using the `file` backend with a PersistentVolume.
 kind: Deployment
 
 persistence:
+  # -- Enable persistent storage for uploaded files
   enabled: false
+  # -- Storage class name (uses cluster default if unset)
   # storageClassName: default
+  # -- PVC access modes
   accessModes:
     - ReadWriteOnce
+  # -- PVC storage size
   size: 10Gi
   # annotations: {}
+  # -- Mount path for file storage inside the container
   path: /home/plik/server/files
 
 dbPersistence:
+  # -- Enable persistent storage for the SQLite database
   enabled: false
+  # -- Storage class name (uses cluster default if unset)
   # storageClassName: default
+  # -- PVC access modes
   accessModes:
     - ReadWriteOnce
+  # -- PVC storage size
   size: 1Gi
   # annotations: {}
+  # -- Mount path for the database inside the container
   path: /home/plik/server/db
 
+# -- Plik server configuration. Values are rendered into the `plikd.cfg` config file.
+# See [server configuration reference](https://github.com/root-gg/plik/tree/master/server/plikd.cfg) for all options.
+# @default -- see sub-values
 plikd:
+  # -- Enable debug mode
   Debug: false
+  # -- Log every HTTP request
   DebugRequests: false
+  # -- Log level (`DEBUG`, `INFO`, `WARNING`, `CRITICAL`)
   LogLevel: "INFO"
 
+  # -- HTTP listen port
   ListenPort: 8080
+  # -- HTTP listen address
   ListenAddress: "0.0.0.0"
+  # -- Prometheus metrics port (0 = disabled)
   MetricsPort: 0
+  # -- Prometheus metrics listen address
   MetricsAddress: "0.0.0.0"
+  # -- URL path prefix (e.g. `/plik`)
   Path: ""
+  # -- Enable HTTPS
   SslEnabled: false
+  # -- Path to TLS certificate
   SslCert: "plik.crt"
+  # -- Path to TLS private key
   SslKey: "plik.key"
+  # -- Minimum TLS version (`tlsv10`, `tlsv11`, `tlsv12`, `tlsv13`)
   TlsVersion: "tlsv10"
+  # -- Disable the web interface
   NoWebInterface: false
+  # -- Custom download domain
   DownloadDomain: ""
+  # -- Additional download domain aliases
   DownloadDomainAlias: []
+  # -- Enable enhanced web security headers (CSP, X-Frame-Options, etc.)
   EnhancedWebSecurity: false
+  # -- User session timeout (e.g. `365d`, `24h`)
   SessionTimeout: "365d"
+  # -- Abuse contact email displayed in the footer
   AbuseContact: ""
+  # -- Path to the webapp distribution directory
   WebappDirectory: "../webapp/dist"
+  # -- Path to the pre-built CLI clients directory
   ClientsDirectory: "../clients"
+  # -- Path to the changelog directory
   ChangelogDirectory: "../changelog"
+  # -- HTTP header to use for source IP (e.g. `X-Forwarded-For`)
   SourceIpHeader: ""
+  # -- IP whitelist for uploads (empty = allow all)
   UploadWhitelist: []
 
+  # -- Maximum file size per upload (e.g. `10GB`, `unlimited`)
   MaxFileSizeStr: "10GB"
+  # -- Maximum total size per user (e.g. `10GB`, `unlimited`)
   MaxUserSizeStr: "unlimited"
+  # -- Maximum number of files per upload
   MaxFilePerUpload: 1000
 
+  # -- Default upload TTL (e.g. `30d`, `24h`)
   DefaultTTLStr: "30d"
+  # -- Maximum upload TTL
   MaxTTLStr: "30d"
 
+  # -- Enable user authentication (`enabled`, `disabled`, `forced`)
   FeatureAuthentication: "disabled"
+  # -- Enable local login
   FeatureLocalLogin: "enabled"
+  # -- Allow users to delete their account
   FeatureDeleteAccount: "enabled"
+  # -- Enable one-shot downloads
   FeatureOneShot: "enabled"
+  # -- Enable removable uploads
   FeatureRemovable: "enabled"
+  # -- Enable streaming uploads
   FeatureStream: "enabled"
+  # -- Enable password-protected uploads
   FeaturePassword: "enabled"
+  # -- Enable upload comments
   FeatureComments: "enabled"
+  # -- Allow users to set a custom TTL
   FeatureSetTTL: "enabled"
+  # -- Allow users to extend an existing TTL
   FeatureExtendTTL: "disabled"
+  # -- Enable pre-built CLI clients download page
   FeatureClients: "enabled"
+  # -- Show GitHub link in the footer
   FeatureGithub: "enabled"
+  # -- Enable plain-text paste mode
   FeatureText: "enabled"
 
-  # Google config (non-sensitive — client ID and domain list only)
+  # -- Google OAuth2 client ID
   GoogleApiClientID: ""
+  # -- Allowed Google domains (empty = allow all)
   GoogleValidDomains: []
 
-  # OVH config (non-sensitive — public endpoint only)
+  # -- OVH API endpoint (e.g. `ovh-eu`, `ovh-ca`)
   OvhApiEndpoint: ""
 
-  # OIDC config (non-sensitive — client ID, provider URL, domains)
+  # -- OpenID Connect client ID
   OIDCClientID: ""
+  # -- OpenID Connect provider discovery URL
   OIDCProviderURL: ""
+  # -- Display name for the OIDC provider
   OIDCProviderName: "OpenID"
+  # -- Allowed OIDC email domains (empty = allow all)
   OIDCValidDomains: []
+  # -- Require verified email from OIDC provider
   OIDCRequireVerifiedEmail: false
 
+  # -- Data backend type (`file`, `gcs`, `s3`, `swift`)
   DataBackend: "file"
+  # -- Non-sensitive data backend configuration.
+  # Keys depend on the backend type. See [data backends](https://github.com/root-gg/plik#data-backends).
   DataBackendConfig:
     Directory: "files"
     # GCS
@@ -191,6 +277,7 @@ plikd:
     # PartSize: 16777216
     # SSE: ""
 
+  # -- Metadata backend configuration (database driver, connection string)
   MetadataBackendConfig:
     Driver: "sqlite3"
     ConnectionString: "/home/plik/server/db/plik.db"
@@ -204,28 +291,28 @@ plikd:
 #   secrets.existingSecret: "my-plik-secret"
 # The external secret must expose the same env var keys listed below.
 secrets:
-  # If set, the chart will NOT create a Secret resource and will reference this
-  # existing Secret instead. The Secret must contain the relevant env var keys.
+  # -- Use an existing Kubernetes Secret instead of creating one.
+  # The Secret must contain the relevant env var keys.
   existingSecret: ""
 
-  # Google OAuth2 — client secret injected as PLIKD_GOOGLE_API_SECRET
+  # -- Google OAuth2 client secret (injected as `PLIKD_GOOGLE_API_SECRET`)
   googleApiSecret: ""
 
-  # OVH OAuth2 — injected as PLIKD_OVH_API_KEY / PLIKD_OVH_API_SECRET
+  # -- OVH API key (injected as `PLIKD_OVH_API_KEY`)
   ovhApiKey: ""
+  # -- OVH API secret (injected as `PLIKD_OVH_API_SECRET`)
   ovhApiSecret: ""
 
-  # OIDC — client secret injected as PLIKD_OIDC_CLIENT_SECRET
+  # -- OIDC client secret (injected as `PLIKD_OIDC_CLIENT_SECRET`)
   oidcClientSecret: ""
 
-  # Data backend sensitive config (e.g. S3 SecretAccessKey, Swift ApiKey).
-  # Injected as PLIKD_DATA_BACKEND_CONFIG (JSON).
-  # Keys defined here are merged with non-sensitive DataBackendConfig at runtime.
+  # -- Sensitive data backend config (merged with `plikd.DataBackendConfig` at runtime).
+  # Injected as `PLIKD_DATA_BACKEND_CONFIG` JSON.
   dataBackend: {}
   #   SecretAccessKey: ""
   #   ApiKey: ""
 
-  # Metadata backend sensitive config (e.g. database Password).
-  # Injected as PLIKD_METADATA_BACKEND_CONFIG (JSON).
+  # -- Sensitive metadata backend config (e.g. database password).
+  # Injected as `PLIKD_METADATA_BACKEND_CONFIG` JSON.
   metadataBackend: {}
   #   Password: ""

--- a/docs/guide/kubernetes.md
+++ b/docs/guide/kubernetes.md
@@ -28,6 +28,16 @@ helm install plik .
 
 The chart supports several modes of deployment. All Plik [configuration](./configuration.md) options are available under the `plikd` key in `values.yaml`.
 
+### Values Reference
+
+A complete table of all configurable values with types, defaults, and descriptions is available in the chart's [README](https://github.com/root-gg/plik/blob/master/charts/plik/README.md#values).
+
+The README is auto-generated with [helm-docs](https://github.com/norwoodj/helm-docs). To regenerate after editing `values.yaml`:
+
+```bash
+make helm-docs
+```
+
 ### Persistence
 
 Plik requires two types of persistent storage when using the `file` data backend:


### PR DESCRIPTION
### What
Add helm-docs support to the Plik Helm chart with a fully generated values reference.

### Why
The chart had no README and values lacked structured documentation, making it hard for users to discover and configure available options.

### Changes
- `charts/plik/values.yaml` — Added `# --` helm-docs annotations to all ~90 configurable values
- `charts/plik/README.md.gotmpl` — Template with installation instructions, quick-start examples, and architecture link
- `charts/plik/README.md` — Auto-generated values reference table
- `Makefile` — New `make helm-docs` target; `make helm` now depends on it for auto-regeneration
- `docs/guide/kubernetes.md` — Added Values Reference section linking to the chart README

### Testing
- YAML validated
- `helm-docs --chart-search-root ./charts` generates the README successfully
- `make helm-docs` target tested