### PR TITLE
fix(ci): add setup-go for nfpm install and add oneshot E2E test

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,10 +50,17 @@ jobs:
       if: github.event_name == 'release'
       run: releaser/helm_release.sh ${GITHUB_REF#refs/tags/}
 
+    - name: Set up Go
+      if: github.event_name == 'release'
+      uses: actions/setup-go@v5
+      with:
+        go-version: stable
+
     - name: Install nfpm
       if: github.event_name == 'release'
       run: |
         go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+        echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
     - name: Install APT repo tools
       if: github.event_name == 'release'


### PR DESCRIPTION
## What
Fix the `nfpm: command not found` error in the release CI workflow and add an E2E test for oneshot uploads.

## Why
The 1.4-RC5 release workflow failed because `nfpm` was not on PATH after `go install`. The oneshot E2E test documents a known issue where the UI text viewer consumes a one-shot file.

## Changes
- **`.github/workflows/release.yaml`**: Add `actions/setup-go@v5` before `nfpm install`, add `GOPATH/bin` to `GITHUB_PATH`
- **`webapp/e2e/download.spec.js`**: Add E2E test showing oneshot file consumed by UI text viewer auto-download

## Testing
- `make test-frontend-e2e` — the new oneshot test passes (confirms the file is consumed)