### PR TITLE
fix(webapp): disable autocapitalize on login input

### DIFF
--- a/webapp/src/views/LoginView.vue
+++ b/webapp/src/views/LoginView.vue
@@ -110,6 +110,7 @@ async function handleOidcLogin() {
                    class="input-field w-full"
                    placeholder="Enter your login"
                    autocomplete="username"
+                   autocapitalize="off"
                    autofocus />
           </div>
           <div>


### PR DESCRIPTION
### What
Add `autocapitalize="off"` to the login input field on the login page.

### Why
On mobile devices, the keyboard suggests an uppercase first letter for `type="text"` inputs. This is inappropriate for a username/login field.

### Changes
- `webapp/src/views/LoginView.vue` — added `autocapitalize="off"` attribute to the login `<input>`