### PR TITLE
feat(webapp): hide text viewer for one-shot and streaming uploads

### DIFF
--- a/webapp/ARCHITECTURE.md
+++ b/webapp/ARCHITECTURE.md
@@ -630,7 +630,7 @@ Reusable CodeMirror 6 wrapper (`CodeEditor.vue`) used in two contexts:
 
 **JSON prettify / validate**: When the detected language is JSON, two action buttons appear in the editor header bar. **Validate** (`JSON.parse()` only) checks syntax and shows a brief green "Valid" flash on success or a dismissable red error banner on failure — it never changes the content. **Prettify** (`JSON.parse()` → `JSON.stringify(…, null, 2)`) validates *and* reformats the content with 2-space indentation. In read-only mode (DownloadView file viewer) prettify updates the displayed view only — it does not modify the file on the server.
 
-**Auto-display**: In `DownloadView.vue`, if an upload contains exactly one text file, the viewer panel opens automatically on mount (or when the file finishes uploading). A watcher on `activeFiles` triggers `viewFile()` for the first file if it's the only one and it's a text file.
+**Auto-display**: In `DownloadView.vue`, if an upload contains exactly one text file, the viewer panel opens automatically on mount (or when the file finishes uploading). A watcher on `activeFiles` triggers `viewFile()` for the first file if it's the only one and it's a text file. **Exception**: auto-display is disabled for one-shot and streaming uploads — one-shot viewing would consume the single download, and streaming files may not be fully stored on the server.
 
 ### Text-File Detection
 
@@ -638,7 +638,7 @@ The `isTextFile()` utility in `utils.js` determines if a file can be viewed in t
 1. **Size**: Max 5 MB (`MAX_VIEWABLE_SIZE`)
 2. **MIME type**: `text/*` prefix only — the server detects MIME types via Go's `http.DetectContentType`, which returns `text/plain` for all text-like content (JS, JSON, Go, Python, etc.) and `application/octet-stream` for binary
 
-`FileRow.vue` uses this to conditionally show a "View" button on uploaded files in download mode.
+`FileRow.vue` uses this to conditionally show a "View" button on uploaded files in download mode. The View button is also hidden for one-shot (`isOneShot` prop) and streaming (`isStream` prop) uploads.
 
 ---
 

--- a/webapp/e2e/download.spec.js
+++ b/webapp/e2e/download.spec.js
@@ -159,6 +159,54 @@ test.describe('Text viewer', () => {
         // Viewer panel should not be open
         await expect(page.locator('#file-viewer-panel')).not.toBeVisible()
     })
+
+    test('View button hidden for one-shot uploads', async ({ page, withConfig }) => {
+        await withConfig({ feature_one_shot: 'default' })
+        await page.goto('/')
+        await page.waitForLoadState('networkidle')
+
+        // Upload a text file (one-shot is on by default via config)
+        const input = page.locator('input[type="file"]')
+        await input.setInputFiles({
+            name: 'oneshot.txt',
+            mimeType: 'text/plain',
+            buffer: Buffer.from('one shot content'),
+        })
+
+        await page.getByRole('button', { name: 'Upload', exact: true }).click()
+        await page.waitForURL(/[?&]id=/, { timeout: 10_000 })
+        await page.waitForLoadState('networkidle')
+
+        // File should be listed
+        await expect(page.getByRole('link', { name: 'oneshot.txt' })).toBeVisible()
+
+        // View button should NOT be visible for one-shot uploads
+        await expect(page.getByRole('button', { name: 'View' })).not.toBeVisible()
+    })
+
+    test('does NOT auto-open for one-shot uploads', async ({ page, withConfig }) => {
+        await withConfig({ feature_one_shot: 'default' })
+        await page.goto('/')
+        await page.waitForLoadState('networkidle')
+
+        // Upload a single text file with one-shot enabled
+        const input = page.locator('input[type="file"]')
+        await input.setInputFiles({
+            name: 'oneshot-auto.txt',
+            mimeType: 'text/plain',
+            buffer: Buffer.from('should not auto open'),
+        })
+
+        await page.getByRole('button', { name: 'Upload', exact: true }).click()
+        await page.waitForURL(/[?&]id=/, { timeout: 10_000 })
+        await page.waitForLoadState('networkidle')
+
+        // File should be listed
+        await expect(page.getByRole('link', { name: 'oneshot-auto.txt' })).toBeVisible()
+
+        // Viewer panel should NOT auto-open for one-shot uploads
+        await expect(page.locator('#file-viewer-panel')).not.toBeVisible()
+    })
 })
 
 test.describe('Add files', () => {

--- a/webapp/e2e/streaming.spec.js
+++ b/webapp/e2e/streaming.spec.js
@@ -163,4 +163,80 @@ test.describe('Streaming uploads', () => {
         expect(capturedUrl).toContain('/stream/')
         expect(capturedUrl).not.toContain('/file/')
     })
+
+    test('View button hidden for streaming uploads', async ({ page, withConfig }) => {
+        await withConfig({ feature_stream: 'enabled' })
+        await page.goto('/')
+        await page.waitForLoadState('networkidle')
+
+        // Enable streaming toggle
+        const streamLabel = page.getByText('Streaming', { exact: false }).first()
+        const toggle = streamLabel.locator('xpath=..').locator('.toggle-switch')
+        await toggle.click()
+
+        // Intercept stream upload to avoid hanging (streaming blocks until consumed)
+        await page.route('**/stream/**', (route) => {
+            if (route.request().method() === 'POST') {
+                return route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ id: 'fake', fileName: 'stream-view.txt' }),
+                })
+            }
+            return route.continue()
+        })
+
+        // Upload a text file
+        const input = page.locator('input[type="file"]')
+        await input.setInputFiles({
+            name: 'stream-view.txt',
+            mimeType: 'text/plain',
+            buffer: Buffer.from('streaming text content'),
+        })
+
+        await page.getByRole('button', { name: 'Upload', exact: true }).click()
+        await page.waitForURL(/[?&]id=/, { timeout: 10_000 })
+        await page.waitForLoadState('networkidle')
+
+        // View button should NOT be visible for streaming uploads
+        await expect(page.getByRole('button', { name: 'View' })).not.toBeVisible()
+    })
+
+    test('text viewer does NOT auto-open for streaming uploads', async ({ page, withConfig }) => {
+        await withConfig({ feature_stream: 'enabled' })
+        await page.goto('/')
+        await page.waitForLoadState('networkidle')
+
+        // Enable streaming toggle
+        const streamLabel = page.getByText('Streaming', { exact: false }).first()
+        const toggle = streamLabel.locator('xpath=..').locator('.toggle-switch')
+        await toggle.click()
+
+        // Intercept stream upload to avoid hanging (streaming blocks until consumed)
+        await page.route('**/stream/**', (route) => {
+            if (route.request().method() === 'POST') {
+                return route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({ id: 'fake', fileName: 'stream-auto.txt' }),
+                })
+            }
+            return route.continue()
+        })
+
+        // Upload a single text file
+        const input = page.locator('input[type="file"]')
+        await input.setInputFiles({
+            name: 'stream-auto.txt',
+            mimeType: 'text/plain',
+            buffer: Buffer.from('should not auto open'),
+        })
+
+        await page.getByRole('button', { name: 'Upload', exact: true }).click()
+        await page.waitForURL(/[?&]id=/, { timeout: 10_000 })
+        await page.waitForLoadState('networkidle')
+
+        // Viewer panel should NOT auto-open for streaming uploads
+        await expect(page.locator('#file-viewer-panel')).not.toBeVisible()
+    })
 })

--- a/webapp/src/components/FileRow.vue
+++ b/webapp/src/components/FileRow.vue
@@ -10,6 +10,7 @@ const props = defineProps({
   mode: { type: String, default: 'upload' }, // 'upload' | 'uploading' | 'download'
   canRemove: { type: Boolean, default: false },
   isStream: { type: Boolean, default: false },
+  isOneShot: { type: Boolean, default: false },
   isE2ee: { type: Boolean, default: false },
 })
 
@@ -218,7 +219,7 @@ function fileUrl() {
                     :text="fileUrl()" />
 
         <!-- View button (download mode, text files only) -->
-        <button v-if="mode === 'download' && file.status === 'uploaded' && isTextFile"
+        <button v-if="mode === 'download' && file.status === 'uploaded' && isTextFile && !isOneShot && !isStream"
                 class="btn bg-accent-500/10 text-accent-400 hover:bg-accent-500/20 px-2 py-1.5 text-xs"
                 title="View file content"
                 @click="emit('view', file)">

--- a/webapp/src/views/DownloadView.vue
+++ b/webapp/src/views/DownloadView.vue
@@ -492,6 +492,8 @@ watch(activeFiles, (files) => {
   // Only auto-view when the entire upload has exactly one file
   const totalUploadFiles = upload.value?.files?.filter(f => f.status !== 'removed' && f.status !== 'deleted')
   if (totalUploadFiles?.length !== 1) return
+  // Don't auto-open for one-shot (viewing consumes the download) or streaming uploads
+  if (upload.value?.oneShot || upload.value?.stream) return
 
   const file = files[0]
   if (file?.status === 'uploaded' && isTextFile(file) && lastAutoViewedId.value !== file.id) {
@@ -648,6 +650,7 @@ watch(activeFiles, (files) => {
                      mode="download"
                      :can-remove="canRemoveFiles"
                      :is-stream="upload.stream"
+                     :is-one-shot="upload.oneShot"
                      :is-e2ee="isE2EE"
                      @remove="deleteFile"
                      @show-qr="openQrFile"


### PR DESCRIPTION
### What
Hide the View button and disable auto-opening the text file viewer for one-shot and streaming uploads.

### Why
- **One-shot**: viewing in the text viewer consumes the single download — the file would become unavailable
- **Streaming**: files may not be fully stored on the server, making the viewer unreliable

### Changes
- `FileRow.vue`: new `isOneShot` prop, View button hidden when `isOneShot || isStream`
- `DownloadView.vue`: passes `isOneShot` prop, auto-open watcher skips one-shot/stream
- `download.spec.js`: 2 e2e tests for one-shot (view hidden + no auto-open)
- `streaming.spec.js`: 2 e2e tests for streaming (view hidden + no auto-open)
- `webapp/ARCHITECTURE.md`: updated docs

### Testing
- 160/160 Playwright e2e tests pass (including 4 new)
- 119/119 Vitest unit tests pass
- Vite build passes