### PR TITLE
feat(client): add ✅/❌ emoji to upload progress bar

### DIFF
--- a/client/progress.go
+++ b/client/progress.go
@@ -64,8 +64,10 @@ func (p *Progress) register(file *plik.File) {
 		if err != nil {
 			// Keep only the first line of the error
 			str := strings.TrimSuffix(strings.SplitAfterN(err.Error(), "\n", 2)[0], "\n")
+			bar.Prefix("❌ " + linePrefix)
 			bar.FinishError(errors.New(str))
 		} else {
+			bar.Prefix("✅ " + linePrefix)
 			bar.Finish()
 		}
 	})


### PR DESCRIPTION
### What
Add ✅/❌ emoji prefix to progress bar lines on upload completion.

### Why
Clearer visual feedback — at a glance you can tell which files succeeded and which failed.

### Changes
- `client/progress.go`: set bar prefix to `✅` or `❌` in the upload callback before finishing

### Testing
- `make lint` — passes
- `make client server` — builds cleanly