### PR TITLE
fix(release): prune old deb packages and preserve docs on gh-pages

### DIFF
--- a/releaser/apt_release.sh
+++ b/releaser/apt_release.sh
@@ -175,6 +175,15 @@ fi
 APT_DIR="$WORKTREE/apt"
 mkdir -p "$APT_DIR/pool/main"
 
+# Remove old versions of packages being replaced
+for DEB in releases/*.deb; do
+  [[ -f "$DEB" ]] || continue
+  PKG_NAME=$(dpkg-deb -f "$DEB" Package)
+  DEB_ARCH=$(dpkg-deb -f "$DEB" Architecture)
+  # Remove any existing versions of this package for this architecture
+  find "$APT_DIR/pool/main/" -name "${PKG_NAME}_*_${DEB_ARCH}.deb" -delete 2>/dev/null || true
+done
+
 # Copy .deb files to the pool
 cp releases/*.deb "$APT_DIR/pool/main/"
 
@@ -251,7 +260,7 @@ fi
 
 # Commit and force-push to gh-pages (single orphan commit, no history)
 cd "$WORKTREE"
-git add apt/
+git add -A
 git commit -m "Update APT repository for $TAG"
 git push --force "$GIT_REMOTE" HEAD:gh-pages
 cd -


### PR DESCRIPTION
### What
Fix two issues in `apt_release.sh` that cause gh-pages bloat and break the docs site.

### Why
Each release was adding ~180 MB of `.deb` packages to the pool without removing old versions. After RC3 + RC5, gh-pages was 530 MB. Additionally, `git add apt/` was only staging the APT directory in the orphan commit, silently dropping the VitePress docs on every release force-push.

### Changes
- **Pool pruning** — before copying new `.deb` files, remove old versions of the same package/architecture from the pool
- **Docs preservation** — change `git add apt/` → `git add -A` so the orphan commit includes all existing content (docs, Helm index, etc.)

### Testing
- Manually pruned RC3 packages from gh-pages and verified RC5 APT install in a `debian:bookworm` container
- Both `plik-client` and `plik-server` install and report correct version `1.4-RC5`