### PR TITLE
fix(security): neutralize SVG/XML content types to prevent XSS (SECU-10)

### DIFF
--- a/server/handlers/get_file.go
+++ b/server/handlers/get_file.go
@@ -64,9 +64,10 @@ func GetFile(ctx *context.Context, resp http.ResponseWriter, req *http.Request) 
 		}
 	}
 
-	// Avoid rendering HTML in browser
-	if strings.Contains(file.Type, "html") {
-		file.Type = "text/plain"
+	// Avoid rendering potentially dangerous content types in the browser
+	// HTML could execute inline scripts, SVG/XML can contain onload handlers (SECU-10)
+	if strings.Contains(file.Type, "html") || strings.Contains(file.Type, "svg") || file.Type == "text/xml" || file.Type == "text/xml; charset=utf-8" {
+		file.Type = "application/octet-stream"
 	}
 
 	// Force the download of the following types as they are blocked by the CSP Header and won't display properly.

--- a/server/handlers/get_file_test.go
+++ b/server/handlers/get_file_test.go
@@ -257,7 +257,59 @@ func TestGetHtmlFile(t *testing.T) {
 	GetFile(ctx, rr, req)
 	context.TestOK(t, rr)
 
-	require.Equal(t, "text/plain", rr.Header().Get("Content-Type"), "invalid content type")
+	require.Equal(t, "application/octet-stream", rr.Header().Get("Content-Type"), "invalid content type")
+}
+
+func TestGetSvgFile(t *testing.T) {
+	config := common.NewConfiguration()
+	ctx := newTestingContext(config)
+
+	upload := &common.Upload{}
+	upload.InitializeForTests()
+
+	file := upload.NewFile()
+	file.Type = "image/svg+xml"
+	file.Status = "uploaded"
+	err := createTestFile(ctx, file, bytes.NewBuffer([]byte("data")))
+	require.NoError(t, err, "unable to create test file")
+
+	ctx.SetUpload(upload)
+	ctx.SetFile(file)
+
+	req, err := http.NewRequest("GET", "/file/", bytes.NewBuffer([]byte{}))
+	require.NoError(t, err, "unable to create new request")
+
+	rr := ctx.NewRecorder(req)
+	GetFile(ctx, rr, req)
+	context.TestOK(t, rr)
+
+	require.Equal(t, "application/octet-stream", rr.Header().Get("Content-Type"), "SVG files should be neutralized to octet-stream")
+}
+
+func TestGetXmlFile(t *testing.T) {
+	config := common.NewConfiguration()
+	ctx := newTestingContext(config)
+
+	upload := &common.Upload{}
+	upload.InitializeForTests()
+
+	file := upload.NewFile()
+	file.Type = "text/xml"
+	file.Status = "uploaded"
+	err := createTestFile(ctx, file, bytes.NewBuffer([]byte("data")))
+	require.NoError(t, err, "unable to create test file")
+
+	ctx.SetUpload(upload)
+	ctx.SetFile(file)
+
+	req, err := http.NewRequest("GET", "/file/", bytes.NewBuffer([]byte{}))
+	require.NoError(t, err, "unable to create new request")
+
+	rr := ctx.NewRecorder(req)
+	GetFile(ctx, rr, req)
+	context.TestOK(t, rr)
+
+	require.Equal(t, "application/octet-stream", rr.Header().Get("Content-Type"), "XML files should be neutralized to octet-stream")
 }
 
 func TestGetFileNoType(t *testing.T) {


### PR DESCRIPTION
## Summary

SVG files uploaded to Plik were served with their detected content type (`text/xml`, `image/svg+xml`) **without being neutralized**, unlike HTML files which were already rewritten to `text/plain`. An attacker could upload an SVG containing `onload="alert(document.cookie)"` and the JavaScript would execute in the Plik domain context when victims visited the download URL.

## Changes

### `server/handlers/get_file.go`
- Neutralize SVG (`image/svg+xml`), XML (`text/xml`) and HTML content types to `application/octet-stream` to force download instead of inline browser rendering
- HTML was previously rewritten to `text/plain`; now consistently uses `application/octet-stream` like the other dangerous types

### `server/handlers/get_file_test.go`
- `TestGetSvgFile` — verifies SVG files are neutralized to `application/octet-stream`
- `TestGetXmlFile` — verifies XML files are neutralized to `application/octet-stream`
- Updated `TestGetHtmlFile` expected content type from `text/plain` to `application/octet-stream`

## Testing
All handler tests pass (`go test ./server/handlers/ -v`).