### PR TITLE
ci(docker): chain build into deploy workflow

### DIFF
--- a/.github/workflows/docker-build-pr.yaml
+++ b/.github/workflows/docker-build-pr.yaml
@@ -5,11 +5,14 @@ on:
     types: [created]
 
 jobs:
-  docker-build:
-    name: Docker Build & Push
+  check-permissions:
+    name: Check Permissions
     # Trigger only on pull request comments and when the comment contains "docker build"
-    if: github.event.issue.pull_request && contains(github.event.comment.body, 'docker build')
+    if: github.event.issue.pull_request && trim(github.event.comment.body) == 'docker build'
     runs-on: ubuntu-latest
+    outputs:
+      head_ref: ${{ steps.pr.outputs.head_ref }}
+      head_repo: ${{ steps.pr.outputs.head_repo }}
     steps:
       - name: Check permissions
         id: check_perms
@@ -47,45 +50,29 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number,
             });
-            return pr;
+            core.setOutput('head_ref', pr.head.ref);
+            core.setOutput('head_repo', pr.head.repo.full_name);
 
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ fromJson(steps.pr.outputs.result).head.ref }}
-          repository: ${{ fromJson(steps.pr.outputs.result).head.repo.full_name }}
+  build:
+    name: Build
+    needs: check-permissions
+    uses: ./.github/workflows/docker-build-reusable.yaml
+    with:
+      pr_number: ${{ github.event.issue.number }}
+      head_ref: ${{ needs.check-permissions.outputs.head_ref }}
+      head_repo: ${{ needs.check-permissions.outputs.head_repo }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Fetch tags
-        run: |
-          git fetch --prune --unshallow --tags
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Compute version
-        id: version
-        run: |
-          LATEST_TAG=$(git describe --tags --abbrev=0)
-          SHORT_COMMIT=$(git rev-parse --short HEAD)
-          VERSION="${LATEST_TAG}-pr-${{ github.event.issue.number }}-${SHORT_COMMIT}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-
-      - name: Build and push
-        env:
-          TAG: pr-${{ github.event.issue.number }}
-          VERSION: ${{ steps.version.outputs.version }}
-          RELEASE: "false"
-          PUSH_TO_DOCKER_HUB: "true"
-        run: make release-and-push-to-docker-hub
-
+  notify:
+    name: Notify
+    needs: [check-permissions, build]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
       - name: Post success comment
-        if: success()
+        if: needs.build.result == 'success'
         uses: actions/github-script@v6
         with:
           script: |
@@ -97,7 +84,7 @@ jobs:
             });
 
       - name: Post failure comment
-        if: failure()
+        if: needs.build.result == 'failure'
         uses: actions/github-script@v6
         with:
           script: |

--- a/.github/workflows/docker-build-reusable.yaml
+++ b/.github/workflows/docker-build-reusable.yaml
@@ -1,0 +1,59 @@
+name: docker-build-reusable
+
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        required: true
+        type: number
+      head_ref:
+        required: true
+        type: string
+      head_repo:
+        required: true
+        type: string
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
+
+jobs:
+  docker-build:
+    name: Docker Build & Push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.head_ref }}
+          repository: ${{ inputs.head_repo }}
+
+      - name: Fetch tags
+        run: |
+          git fetch --prune --unshallow --tags
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Compute version
+        id: version
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0)
+          SHORT_COMMIT=$(git rev-parse --short HEAD)
+          VERSION="${LATEST_TAG}-pr-${{ inputs.pr_number }}-${SHORT_COMMIT}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        env:
+          TAG: pr-${{ inputs.pr_number }}
+          VERSION: ${{ steps.version.outputs.version }}
+          RELEASE: "false"
+          PUSH_TO_DOCKER_HUB: "true"
+        run: make release-and-push-to-docker-hub

--- a/.github/workflows/docker-deploy-pr.yaml
+++ b/.github/workflows/docker-deploy-pr.yaml
@@ -5,11 +5,15 @@ on:
     types: [created]
 
 jobs:
-  docker-deploy:
-    name: Docker Deploy to Production
+  check-permissions:
+    name: Check Permissions
     # Trigger only on pull request comments and when the comment contains "docker deploy"
-    if: github.event.issue.pull_request && contains(github.event.comment.body, 'docker deploy')
+    if: github.event.issue.pull_request && trim(github.event.comment.body) == 'docker deploy'
     runs-on: ubuntu-latest
+    outputs:
+      head_ref: ${{ steps.pr.outputs.head_ref }}
+      head_repo: ${{ steps.pr.outputs.head_repo }}
+      image_exists: ${{ steps.check_image.outputs.exists }}
     steps:
       - name: Check permissions
         id: check_perms
@@ -37,6 +41,50 @@ jobs:
               content: 'rocket',
             });
 
+      - name: Get PR info
+        id: pr
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('head_ref', pr.head.ref);
+            core.setOutput('head_repo', pr.head.repo.full_name);
+
+      - name: Check if image exists
+        id: check_image
+        run: |
+          if docker manifest inspect rootgg/plik:pr-${{ github.event.issue.number }} > /dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "✅ Image rootgg/plik:pr-${{ github.event.issue.number }} already exists"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "⚙️ Image rootgg/plik:pr-${{ github.event.issue.number }} not found, will build first"
+          fi
+
+  build:
+    name: Build (if needed)
+    needs: check-permissions
+    if: needs.check-permissions.outputs.image_exists == 'false'
+    uses: ./.github/workflows/docker-build-reusable.yaml
+    with:
+      pr_number: ${{ github.event.issue.number }}
+      head_ref: ${{ needs.check-permissions.outputs.head_ref }}
+      head_repo: ${{ needs.check-permissions.outputs.head_repo }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  deploy:
+    name: Deploy
+    needs: [check-permissions, build]
+    # Run if permissions passed and build succeeded or was skipped (image already existed)
+    if: always() && needs.check-permissions.result == 'success' && (needs.build.result == 'success' || needs.build.result == 'skipped')
+    runs-on: ubuntu-latest
+    steps:
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v0.1.10
         with:
@@ -50,8 +98,27 @@ jobs:
             docker compose up -d plik
             docker image prune -f
 
+  notify:
+    name: Notify
+    needs: [check-permissions, build, deploy]
+    runs-on: ubuntu-latest
+    if: always() && needs.check-permissions.result == 'success'
+    steps:
       - name: Post success comment
-        if: success()
+        if: needs.deploy.result == 'success'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const built = '${{ needs.build.result }}' === 'success' ? ' (freshly built)' : '';
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `🚀 **Deployment Successful!**\n\nThe instance at [plik.root.gg](https://plik.root.gg) has been redeployed with image \`rootgg/plik:pr-${context.issue.number}\`${built}.`
+            });
+
+      - name: Post build failure comment
+        if: needs.build.result == 'failure'
         uses: actions/github-script@v6
         with:
           script: |
@@ -59,11 +126,11 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `🚀 **Deployment Successful!**\n\nThe instance at [plik.root.gg](https://plik.root.gg) has been redeployed with image \`rootgg/plik:pr-${context.issue.number}\`.`
+              body: `❌ **Build Failed!**\n\nThe Docker image could not be built. Check the [workflow logs](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.`
             });
 
-      - name: Post failure comment
-        if: failure()
+      - name: Post deploy failure comment
+        if: needs.deploy.result == 'failure'
         uses: actions/github-script@v6
         with:
           script: |


### PR DESCRIPTION
### What
`docker deploy` now automatically builds the image if it doesn't exist on Docker Hub, removing the need to comment `docker build` first.

### Why
Previously deploying a PR required two comments (`docker build` → wait → `docker deploy`). Now one comment does both.

### Changes
- New `docker-build-reusable.yaml` — reusable workflow with build+push logic
- `docker-build-pr.yaml` — calls reusable, exact match trigger, permission-aware notify
- `docker-deploy-pr.yaml` — checks image via `docker manifest inspect`, conditionally builds, then deploys
- Exact match (`trim() ==`) instead of `contains()` for comment triggers
- Deploy and notify jobs guarded against permission failures

### Testing
- YAML validated
- Needs real-world testing: comment `docker deploy` on a PR with/without existing image