### PR TITLE
fix(data): clean up range request support nits

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -221,7 +221,7 @@ When processing a request, limits are resolved via the custom `Context`:
 | POST | `/file/{uploadID}` | `AddFile` | Token | Add file to upload |
 | POST | `/file/{uploadID}/{fileID}/{filename}` | `AddFile` | Token | Add file with known ID (stream mode) |
 | DELETE | `/file/{uploadID}/{fileID}/{filename}` | `RemoveFile` | Token | Remove file |
-| HEAD/GET | `/file/{uploadID}/{fileID}/{filename}` | `GetFile` | Token | Download file |
+| HEAD/GET | `/file/{uploadID}/{fileID}/{filename}` | `GetFile` | Token | Download file (supports HTTP range requests) |
 | POST | `/stream/{uploadID}/{fileID}/{filename}` | `AddFile` | Token | Stream upload |
 | HEAD/GET | `/stream/{uploadID}/{fileID}/{filename}` | `GetFile` | Token | Stream download |
 | HEAD/GET | `/archive/{uploadID}/{filename}` | `GetArchive` | Token | Download as zip |
@@ -371,7 +371,7 @@ Both are disabled by default (`enabled: false`) and fall back to `emptyDir` when
 ```go
 type Backend interface {
     AddFile(file *common.File, reader io.Reader) (err error)
-    GetFile(file *common.File) (reader io.ReadCloser, err error)
+    GetFile(file *common.File) (reader io.ReadSeekCloser, err error)
     RemoveFile(file *common.File) (err error)  // must not fail if file not found
 }
 ```

--- a/server/ARCHITECTURE.md
+++ b/server/ARCHITECTURE.md
@@ -98,7 +98,7 @@ The `Backend` interface is minimal (3 methods):
 ```go
 type Backend interface {
     AddFile(file *common.File, reader io.Reader) (err error)
-    GetFile(file *common.File) (reader io.ReadCloser, err error)
+    GetFile(file *common.File) (reader io.ReadSeekCloser, err error)
     RemoveFile(file *common.File) (err error)
 }
 ```
@@ -221,7 +221,7 @@ Each handler file contains one or more `http.Handler` functions.
 | `create_upload.go` | `CreateUpload` | Create upload with options, validate config/quotas |
 | `add_file.go` | `AddFile` | Upload file to existing upload (multipart) |
 | `get_upload.go` | `GetUpload` | Return upload metadata |
-| `get_file.go` | `GetFile` | Download file, handle OneShot, extend TTL. E2EE uploads: redirects webapp to download page, forces `application/octet-stream` |
+| `get_file.go` | `GetFile` | Download file, handle OneShot, extend TTL, support HTTP range requests (via `http.ServeContent` for non-stream/non-oneshot). E2EE uploads: redirects webapp to download page, forces `application/octet-stream` |
 | `get_archive.go` | `GetArchive` | Download all files as zip |
 | `remove_file.go` | `RemoveFile` | Mark file as removed |
 | `remove_upload.go` | `RemoveUpload` | Soft-delete upload |

--- a/server/data/gcs/gcs.go
+++ b/server/data/gcs/gcs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"sync/atomic"
 
 	"cloud.google.com/go/storage"
 	"github.com/root-gg/utils"
@@ -24,7 +23,6 @@ type gcsReadSeekCloser struct {
 	obj       *storage.ObjectHandle
 	r         *storage.Reader
 	pos, size int64
-	nread     int64 // Read/write with atomic
 }
 
 func newReader(ctx context.Context, obj *storage.ObjectHandle) (*gcsReadSeekCloser, error) {
@@ -56,7 +54,6 @@ func (r *gcsReadSeekCloser) Read(dest []byte) (int, error) {
 	}
 	n, err := r.r.Read(dest)
 	r.pos += int64(n)
-	atomic.AddInt64(&r.nread, int64(n))
 	return n, err
 }
 
@@ -67,7 +64,7 @@ func (r *gcsReadSeekCloser) Seek(offset int64, whence int) (int64, error) {
 	case io.SeekStart:
 		newPos = offset
 	case io.SeekCurrent:
-		newPos += r.pos + offset
+		newPos = r.pos + offset
 	case io.SeekEnd:
 		newPos = r.size + offset
 	default:
@@ -96,12 +93,6 @@ func (r *gcsReadSeekCloser) Close() error {
 	err := r.r.Close()
 	r.r = nil
 	return err
-}
-
-// NRead reports the number of bytes that have been read from Reader.
-// This is safe to call concurrently with Read.
-func (r *gcsReadSeekCloser) NRead() int64 {
-	return atomic.LoadInt64(&r.nread)
 }
 
 // Ensure File Data Backend implements data.Backend interface

--- a/server/data/testing/testing.go
+++ b/server/data/testing/testing.go
@@ -12,7 +12,7 @@ import (
 // Ensure Testing Data Backend implements data.Backend interface
 var _ data.Backend = (*Backend)(nil)
 
-// This is like a bytes.Buffer but seekable. We implent io.ReadSeekCloser
+// Buffer is like bytes.Buffer but seekable. Implements io.ReadSeekCloser.
 type Buffer struct {
 	buf []byte
 	off int
@@ -20,8 +20,6 @@ type Buffer struct {
 
 func (b *Buffer) Read(p []byte) (n int, err error) {
 	if len(b.buf) <= b.off {
-		b.buf = b.buf[:0]
-		b.off = 0
 		if len(p) == 0 {
 			return 0, nil
 		}


### PR DESCRIPTION
## Description

### What
Post-merge cleanup of minor issues found during the second-pass review of PR #603 (range request support).

### Why
These nits were identified during review but were non-blocking. Now that #603 is merged, this cleans them up.

### Changes
- **`server/data/gcs/gcs.go`**: Fix `SeekCurrent` using `+=` on zero-init var (misleading but functionally correct → now uses `=`). Remove dead `NRead()` method, `nread` field, and `sync/atomic` import carried over from the `bobg/gcsobj` reference implementation.
- **`server/data/testing/testing.go`**: Fix typo "implent" → "Implements". Remove destructive `b.buf = b.buf[:0]` + `b.off = 0` on EOF that zeroed the underlying slice, breaking `io.ReadSeeker` contract for Seek-after-full-read.
- **`ARCHITECTURE.md`** (root + server): Update `Backend` interface `GetFile` signature from `io.ReadCloser` → `io.ReadSeekCloser`. Add range request mention to `GetFile` handler description.

### Testing
- `make lint` ✅
- `make client server` ✅
- `make test` ✅ (all packages pass)
- `make vuln` ✅