### PR TITLE
fix(webapp): mobile responsive layout fixes

### DIFF
--- a/webapp/src/components/EditUserModal.vue
+++ b/webapp/src/components/EditUserModal.vue
@@ -38,7 +38,7 @@ function clampField(field) {
     <div v-if="modelValue"
          class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
          @mousedown.self="close">
-      <div class="glass-card p-6 max-w-md w-full space-y-5 animate-fade-in max-h-[90vh] overflow-y-auto">
+      <div class="glass-card p-4 sm:p-6 max-w-md w-full space-y-5 animate-fade-in max-h-[90vh] overflow-y-auto">
         <h2 class="text-lg font-semibold text-surface-200">{{ title }}</h2>
 
         <!-- Error -->

--- a/webapp/src/components/UploadControls.vue
+++ b/webapp/src/components/UploadControls.vue
@@ -36,7 +36,7 @@ const emit = defineEmits(['update:sort-by', 'update:sort-order', 'toggle-filter'
       </div>
     </div>
     <!-- Badge filters -->
-    <div class="flex items-center gap-2 text-surface-400">
+    <div class="flex flex-wrap items-center gap-2 text-surface-400">
         <span>Filter:</span>
         <button @click="emit('toggle-filter', 'oneShot')"
                 :class="badgeFilters.oneShot ? 'bg-amber-500/20 text-amber-400 ring-1 ring-amber-500/50' : 'text-surface-500 hover:text-surface-300'"

--- a/webapp/src/style.css
+++ b/webapp/src/style.css
@@ -32,6 +32,7 @@
   body {
     @apply bg-surface-950 text-surface-100 antialiased;
     font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    overflow-x: hidden;
   }
 
   * {

--- a/webapp/src/views/AdminView.vue
+++ b/webapp/src/views/AdminView.vue
@@ -941,7 +941,7 @@ onMounted(async () => {
       <div v-if="showCreateUser"
            class="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
            @mousedown.self="showCreateUser = false">
-        <div class="glass-card p-6 max-w-md w-full space-y-5 animate-fade-in max-h-[90vh] overflow-y-auto">
+        <div class="glass-card p-4 sm:p-6 max-w-md w-full space-y-5 animate-fade-in max-h-[90vh] overflow-y-auto">
           <h2 class="text-lg font-semibold text-surface-200">Create User</h2>
 
           <div v-if="createError" class="text-sm text-red-400 bg-red-500/10 rounded-lg px-3 py-2">


### PR DESCRIPTION
## Description

### What
Fix content clipping on the left side of the screen on narrow mobile viewports (~390px).

### Why
On mobile devices, the admin dashboard sidebar labels, badge filter buttons, and Create User modal form labels were being clipped/cut off at the left edge of the screen.

### Changes
- **`style.css`** — Add `overflow-x: hidden` on `body` as a global safety net against horizontal scroll on mobile
- **`UploadControls.vue`** — Add `flex-wrap` to badge filter container so buttons wrap to a second line instead of overflowing
- **`EditUserModal.vue`** — Reduce padding from `p-6` to `p-4 sm:p-6` so the modal has more room on narrow screens
- **`AdminView.vue`** — Same responsive padding fix on the inline Create User modal

### Testing
- Frontend build passes (`make frontend`)
- All 140 unit tests pass (`make test-frontend`)
- Visual verification at reduced viewport via browser