### PR TITLE
feat(webapp): add help tooltips to upload settings

### DIFF
--- a/webapp/ARCHITECTURE.md
+++ b/webapp/ARCHITECTURE.md
@@ -478,7 +478,7 @@ App.vue
 ├── AppHeader.vue          — top nav bar (Upload, CLI, Source, user/admin links)
 ├── RootView.vue           — switches between Upload/Download based on query.id
 │   ├── UploadView.vue     — file staging, settings, upload execution
-│   │   ├── UploadSidebar  — upload settings (one-shot, stream, TTL, E2EE, etc.)
+│   │   ├── UploadSidebar  — upload settings (one-shot, stream, TTL, E2EE, etc.) with (?) help tooltips
 │   │   ├── FileRow        — individual file display
 │   │   └── CodeEditor     — text paste mode with syntax highlighting
 │   └── DownloadView.vue   — file list, admin actions
@@ -640,8 +640,12 @@ The `style.css` file defines custom utility classes via `@utility` (Tailwind v4 
 | `toggle-switch`    | Toggle switch base                                |
 | `toggle-dot`       | Toggle switch dot (animated)                      |
 | `input-field`      | Styled text input                                 |
-| `sidebar-section`  | Glass-card styled sidebar section                 |
+| `sidebar-section`  | Glass-card styled sidebar section (`overflow: visible` for tooltips) |
 | `file-row`         | Glass-card styled file row with hover effect      |
+| `setting-help`     | Small muted (?) circle icon for setting help      |
+| `setting-tooltip`  | Absolute-positioned tooltip bubble (shown on hover/focus) |
+
+> **Note**: The `.setting-help-wrap` CSS class (not a `@utility`) controls tooltip visibility via `:hover` and `:focus-within`.
 
 > **Gotcha**: These are `@utility` blocks, NOT traditional CSS classes or Tailwind `@apply`. They follow Tailwind v4's custom utility syntax and generate single utility classes.
 

--- a/webapp/e2e/settings.spec.js
+++ b/webapp/e2e/settings.spec.js
@@ -345,3 +345,76 @@ test.describe('Header feature flags', () => {
     })
 })
 
+// ── Setting Help Tooltips ─────────────────────────────────────────────────
+
+test.describe('Setting help tooltips', () => {
+    const ALL_FEATURES = {
+        feature_one_shot: 'enabled',
+        feature_stream: 'enabled',
+        feature_removable: 'enabled',
+        feature_e2ee: 'enabled',
+        feature_password: 'enabled',
+        feature_comments: 'enabled',
+        feature_extend_ttl: 'enabled',
+    }
+
+    const TOOLTIP_DATA = [
+        { label: 'Destruct after download', tooltip: 'Files are permanently deleted after they are downloaded once' },
+        { label: 'Streaming', tooltip: 'Files are streamed directly to the downloader without being stored on the server' },
+        { label: 'Removable', tooltip: 'Anyone with the link can delete uploaded files' },
+        { label: 'End-to-End Encryption', tooltip: 'Files are encrypted in the browser before upload' },
+        { label: 'Password', tooltip: 'Protect the upload with HTTP basic authentication credentials' },
+        { label: 'Comment', tooltip: 'Add a Markdown-formatted message to the download page' },
+        { label: 'Extend TTL on access', tooltip: 'Reset the expiration timer each time a file is accessed' },
+    ]
+
+    for (const { label, tooltip } of TOOLTIP_DATA) {
+        test(`${label} has a help icon`, async ({ page, withConfig }) => {
+            await withConfig(ALL_FEATURES)
+            await page.goto('/')
+            await page.waitForLoadState('networkidle')
+
+            // Locate the (?) icon near the label
+            const helpIcon = page.getByText(label, { exact: false }).first()
+                .locator('xpath=..').locator('.setting-help')
+            await expect(helpIcon).toBeVisible()
+            await expect(helpIcon).toHaveText('?')
+        })
+    }
+
+    test('tooltip appears on hover', async ({ page, withConfig }) => {
+        await withConfig(ALL_FEATURES)
+        await page.goto('/')
+        await page.waitForLoadState('networkidle')
+
+        // Find the help wrapper near "Destruct after download"
+        const helpWrap = page.getByText('Destruct after download', { exact: false }).first()
+            .locator('xpath=..').locator('.setting-help-wrap')
+        const tooltipEl = helpWrap.locator('.setting-tooltip')
+
+        // Tooltip should be hidden initially (opacity 0)
+        await expect(tooltipEl).toBeAttached()
+
+        // Hover over the (?) icon
+        await helpWrap.locator('.setting-help').hover()
+
+        // Tooltip should now be visible
+        await expect(tooltipEl).toHaveCSS('opacity', '1')
+        await expect(tooltipEl).toContainText('Files are permanently deleted after they are downloaded once')
+    })
+
+    test('tooltip appears on keyboard focus', async ({ page, withConfig }) => {
+        await withConfig(ALL_FEATURES)
+        await page.goto('/')
+        await page.waitForLoadState('networkidle')
+
+        // Focus the help icon via keyboard (it has tabindex=0)
+        const helpIcon = page.getByText('Destruct after download', { exact: false }).first()
+            .locator('xpath=..').locator('.setting-help')
+        await helpIcon.focus()
+
+        // Tooltip should be visible via :focus-within
+        const tooltipEl = helpIcon.locator('xpath=..').locator('.setting-tooltip')
+        await expect(tooltipEl).toHaveCSS('opacity', '1')
+    })
+})

--- a/webapp/src/components/UploadSidebar.vue
+++ b/webapp/src/components/UploadSidebar.vue
@@ -119,7 +119,7 @@ const hasAnySettings = computed(() =>
 <template>
   <aside v-if="hasAnySettings" class="w-full md:w-80 md:shrink-0 p-4 space-y-3 animate-slide-in">
     <!-- Upload Settings -->
-    <div class="sidebar-section">
+    <div class="sidebar-section relative z-10">
       <h3 class="text-xs font-semibold text-surface-400 uppercase tracking-wider mb-2">Upload Settings</h3>
 
       <!-- One Shot -->
@@ -132,6 +132,10 @@ const hasAnySettings = computed(() =>
             <path stroke-linecap="round" stroke-width="2" d="M14 9l2-2" />
           </svg>
           Destruct after download
+          <span class="setting-help-wrap relative" @click.prevent.stop>
+            <span class="setting-help" tabindex="0" role="button" aria-label="Help">?</span>
+            <span class="setting-tooltip">Files are permanently deleted after they are downloaded once</span>
+          </span>
         </span>
         <button type="button"
                 class="toggle-switch"
@@ -150,6 +154,10 @@ const hasAnySettings = computed(() =>
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.636 18.364a9 9 0 010-12.728m12.728 0a9 9 0 010 12.728M9.172 15.828a5 5 0 010-7.072m5.656 0a5 5 0 010 7.072M12 12h.01" />
           </svg>
           Streaming
+          <span class="setting-help-wrap relative" @click.prevent.stop>
+            <span class="setting-help" tabindex="0" role="button" aria-label="Help">?</span>
+            <span class="setting-tooltip">Files are streamed directly to the downloader without being stored on the server</span>
+          </span>
         </span>
         <button type="button"
                 class="toggle-switch"
@@ -168,6 +176,10 @@ const hasAnySettings = computed(() =>
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
           </svg>
           Removable
+          <span class="setting-help-wrap relative" @click.prevent.stop>
+            <span class="setting-help" tabindex="0" role="button" aria-label="Help">?</span>
+            <span class="setting-tooltip">Anyone with the link can delete uploaded files</span>
+          </span>
         </span>
         <button type="button"
                 class="toggle-switch"
@@ -187,6 +199,10 @@ const hasAnySettings = computed(() =>
                     d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
             </svg>
             End-to-End Encryption
+            <span class="setting-help-wrap relative" @click.prevent.stop>
+              <span class="setting-help" tabindex="0" role="button" aria-label="Help">?</span>
+              <span class="setting-tooltip">Files are encrypted in the browser before upload — only someone with the passphrase can decrypt them</span>
+            </span>
           </span>
           <button type="button"
                   class="toggle-switch"
@@ -228,6 +244,10 @@ const hasAnySettings = computed(() =>
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
             </svg>
             Password
+            <span class="setting-help-wrap relative" @click.prevent.stop>
+              <span class="setting-help" tabindex="0" role="button" aria-label="Help">?</span>
+              <span class="setting-tooltip">Protect the upload with HTTP basic authentication credentials</span>
+            </span>
           </span>
           <button type="button"
                   class="toggle-switch"
@@ -273,6 +293,10 @@ const hasAnySettings = computed(() =>
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
           </svg>
           Comment
+          <span class="setting-help-wrap relative" @click.prevent.stop>
+            <span class="setting-help" tabindex="0" role="button" aria-label="Help">?</span>
+            <span class="setting-tooltip">Add a Markdown-formatted message to the download page</span>
+          </span>
         </span>
         <button type="button"
                 class="toggle-switch"
@@ -291,6 +315,10 @@ const hasAnySettings = computed(() =>
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
           </svg>
           Extend TTL on access
+          <span class="setting-help-wrap relative" @click.prevent.stop>
+            <span class="setting-help" tabindex="0" role="button" aria-label="Help">?</span>
+            <span class="setting-tooltip">Reset the expiration timer each time a file is accessed</span>
+          </span>
         </span>
         <button type="button"
                 class="toggle-switch"
@@ -314,6 +342,10 @@ const hasAnySettings = computed(() =>
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.178 8c5.096 0 5.096 8 0 8-5.095 0-7.133-8-12.739-8-4.585 0-4.585 8 0 8 5.606 0 7.644-8 12.74-8z" />
           </svg>
           Never expires
+          <span class="setting-help-wrap relative" @click.prevent.stop>
+            <span class="setting-help" tabindex="0" role="button" aria-label="Help">?</span>
+            <span class="setting-tooltip">The upload will never be automatically deleted</span>
+          </span>
         </span>
         <button type="button"
                 class="toggle-switch"

--- a/webapp/src/style.css
+++ b/webapp/src/style.css
@@ -366,6 +366,7 @@
   border-radius: 0.75rem;
   box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
   padding: 1rem;
+  overflow: visible;
 
   &>*+* {
     margin-top: 0.75rem;
@@ -387,6 +388,71 @@
   &:hover {
     background-color: color-mix(in srgb, var(--color-surface-700) 40%, transparent);
   }
+}
+
+/* ── Setting Help Tooltips ── */
+@utility setting-help {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 0.875rem;
+  height: 0.875rem;
+  border-radius: 9999px;
+  border: 1px solid var(--color-surface-500);
+  color: var(--color-surface-500);
+  font-size: 0.6rem;
+  font-weight: 600;
+  line-height: 1;
+  cursor: help;
+  transition: all 0.15s;
+  flex-shrink: 0;
+
+  &:hover,
+  &:focus {
+    color: var(--color-surface-200);
+    border-color: var(--color-surface-300);
+  }
+}
+
+@utility setting-tooltip {
+  position: absolute;
+  left: 50%;
+  top: calc(100% + 6px);
+  transform: translateX(-50%);
+  width: max-content;
+  max-width: 220px;
+  padding: 0.375rem 0.625rem;
+  background-color: color-mix(in srgb, var(--color-surface-800) 95%, transparent);
+  backdrop-filter: blur(12px);
+  border: 1px solid color-mix(in srgb, var(--color-surface-600) 60%, transparent);
+  border-radius: 0.375rem;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 0.3);
+  color: var(--color-surface-200);
+  font-size: 0.6875rem;
+  line-height: 1.4;
+  white-space: normal;
+  text-align: center;
+  z-index: 50;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+/* Arrow */
+.setting-tooltip::before {
+  content: '';
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 4px solid transparent;
+  border-bottom-color: color-mix(in srgb, var(--color-surface-600) 60%, transparent);
+}
+
+/* Show tooltip on hover or keyboard focus */
+.setting-help-wrap:hover .setting-tooltip,
+.setting-help-wrap:focus-within .setting-tooltip {
+  opacity: 1;
 }
 
 /* ── Animations ── */


### PR DESCRIPTION
## What
Small (?) help icons next to each upload setting toggle. Hover (desktop) or tap (mobile) to see what each option does.

## Why
Settings like "Streaming" or "Extend TTL on access" aren't self-explanatory for new users.

## Changes
- **style.css** — `setting-help`, `setting-tooltip` CSS utilities + `overflow: visible` on `sidebar-section`
- **UploadSidebar.vue** — (?) icons with tooltip text on all 8 settings, `z-10` on settings section for stacking
- **settings.spec.js** — 9 new E2E tests (icon presence × 7, hover, keyboard focus)
- **ARCHITECTURE.md** — updated CSS utilities table and component tree

## Testing
- Visual verification in browser (hover + click + mobile tap)
- `make frontend` ✅
- Unit tests: 140/140 ✅
- E2E: 9 new tooltip tests added