### PR TITLE
feat(webapp): add inline video and audio playback

### DIFF
--- a/webapp/ARCHITECTURE.md
+++ b/webapp/ARCHITECTURE.md
@@ -701,14 +701,26 @@ Default tab for markdown files in the download viewer is **Preview**; in the pas
 When viewing an image file (`image/*` MIME type), the file viewer renders an `<img>` tag directly from the server URL — no content fetching or text decoding required.
 
 - **`isImageFile(file)`** in `utils.js` checks that the MIME type starts with `image/`
-- **`isViewableFile(file)`** combines `isTextFile(file) || isImageFile(file)` — used by `FileRow` for the View button and the auto-view watcher
+- **`isViewableFile(file)`** combines `isTextFile(file) || isImageFile(file) || isVideoFile(file) || isAudioFile(file)` — used by `FileRow` for the View button and the auto-view watcher
 - No file size limit for images (browsers handle large images natively)
 - The viewer header shows a landscape-photo icon (instead of the code angle-brackets icon) for image files
 - E2E encrypted images are not supported in the inline viewer (same limitation as text viewer)
 
+### Video & Audio Playback
+
+Video (`video/*`) and audio (`audio/*`) files are played inline using native HTML5 `<video>` and `<audio>` elements.
+
+- **`isVideoFile(file)`** / **`isAudioFile(file)`** in `utils.js` check MIME type prefixes
+- No file size limit — browsers handle streaming playback natively via range requests
+- The `src` attribute is set directly on `<video>`/`<audio>` (NOT via `<source>` children, which causes browsers to make multiple probe requests)
+- `preload="metadata"` lets the browser fetch duration/dimensions without downloading the full file
+- The viewer header shows a film icon for video and a music-note icon for audio
+- The Copy button is hidden for video/audio (content isn't text)
+- E2E encrypted media is not supported in the inline player (same limitation as images)
+
 ### Viewer Navigation
 
-When an upload contains multiple viewable files (text or image), the viewer shows prev/next navigation:
+When an upload contains multiple viewable files (text, image, video, or audio), the viewer shows prev/next navigation:
 
 - **Arrow buttons** (‹ ›) with a position indicator (`2/5`) appear in the viewer header
 - **Keyboard shortcuts**: `ArrowLeft` / `ArrowRight` to navigate, `Escape` to close

--- a/webapp/src/__tests__/utils.test.js
+++ b/webapp/src/__tests__/utils.test.js
@@ -21,6 +21,8 @@ import {
     isTextFile,
     isMarkdownFile,
     isImageFile,
+    isVideoFile,
+    isAudioFile,
     isViewableFile,
     MAX_VIEWABLE_SIZE,
     getUploadUrl,
@@ -547,6 +549,62 @@ describe('isImageFile', () => {
     })
 })
 
+// ── isVideoFile ──
+
+describe('isVideoFile', () => {
+    it('returns true for video/mp4', () => {
+        expect(isVideoFile({ fileType: 'video/mp4' })).toBe(true)
+    })
+
+    it('returns true for video/webm', () => {
+        expect(isVideoFile({ fileType: 'video/webm' })).toBe(true)
+    })
+
+    it('returns true for video/ogg', () => {
+        expect(isVideoFile({ fileType: 'video/ogg' })).toBe(true)
+    })
+
+    it('returns false for text/plain', () => {
+        expect(isVideoFile({ fileType: 'text/plain' })).toBe(false)
+    })
+
+    it('returns false for application/octet-stream', () => {
+        expect(isVideoFile({ fileType: 'application/octet-stream' })).toBe(false)
+    })
+
+    it('returns false when fileType is missing', () => {
+        expect(isVideoFile({})).toBe(false)
+    })
+})
+
+// ── isAudioFile ──
+
+describe('isAudioFile', () => {
+    it('returns true for audio/mpeg', () => {
+        expect(isAudioFile({ fileType: 'audio/mpeg' })).toBe(true)
+    })
+
+    it('returns true for audio/ogg', () => {
+        expect(isAudioFile({ fileType: 'audio/ogg' })).toBe(true)
+    })
+
+    it('returns true for audio/wav', () => {
+        expect(isAudioFile({ fileType: 'audio/wav' })).toBe(true)
+    })
+
+    it('returns false for text/plain', () => {
+        expect(isAudioFile({ fileType: 'text/plain' })).toBe(false)
+    })
+
+    it('returns false for application/octet-stream', () => {
+        expect(isAudioFile({ fileType: 'application/octet-stream' })).toBe(false)
+    })
+
+    it('returns false when fileType is missing', () => {
+        expect(isAudioFile({})).toBe(false)
+    })
+})
+
 // ── isViewableFile ──
 
 describe('isViewableFile', () => {
@@ -568,6 +626,14 @@ describe('isViewableFile', () => {
 
     it('returns true for large images (no size limit)', () => {
         expect(isViewableFile({ fileType: 'image/png', fileSize: 50 * 1024 * 1024 })).toBe(true)
+    })
+
+    it('returns true for video files', () => {
+        expect(isViewableFile({ fileType: 'video/mp4' })).toBe(true)
+    })
+
+    it('returns true for audio files', () => {
+        expect(isViewableFile({ fileType: 'audio/mpeg' })).toBe(true)
     })
 })
 

--- a/webapp/src/utils.js
+++ b/webapp/src/utils.js
@@ -295,9 +295,28 @@ export function isImageFile(file) {
 }
 
 /**
- * Determine if a file can be previewed inline (text or image).
- * Combines isTextFile and isImageFile for a single viewability check.
+ * Determine if a file is a video (playable inline via native <video>).
+ * Checks that the MIME type starts with video/.
+ * No size limit — browsers handle streaming playback natively.
+ */
+export function isVideoFile(file) {
+    const mime = (file.fileType || '').toLowerCase()
+    return mime.startsWith('video/')
+}
+
+/**
+ * Determine if a file is audio (playable inline via native <audio>).
+ * Checks that the MIME type starts with audio/.
+ */
+export function isAudioFile(file) {
+    const mime = (file.fileType || '').toLowerCase()
+    return mime.startsWith('audio/')
+}
+
+/**
+ * Determine if a file can be previewed inline (text, image, video, or audio).
+ * Combines detection helpers for a single viewability check.
  */
 export function isViewableFile(file) {
-    return isTextFile(file) || isImageFile(file)
+    return isTextFile(file) || isImageFile(file) || isVideoFile(file) || isAudioFile(file)
 }

--- a/webapp/src/views/DownloadView.vue
+++ b/webapp/src/views/DownloadView.vue
@@ -2,7 +2,7 @@
 import { ref, onMounted, onUnmounted, computed, nextTick, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { getUpload, removeUpload, removeFile as apiRemoveFile, uploadFile, getFileURL } from '../api.js'
-import { generateRef, isMarkdownFile, isImageFile, isViewableFile } from '../utils.js'
+import { generateRef, isMarkdownFile, isImageFile, isVideoFile, isAudioFile, isViewableFile } from '../utils.js'
 import { fetchAndDecrypt } from '../crypto.js'
 import { getToken, setToken } from '../tokenStore.js'
 import { consumePendingFiles } from '../pendingUploadStore.js'
@@ -65,6 +65,16 @@ const viewingImageUrl = computed(() => {
   if (!isViewingImage.value) return ''
   return getFileURL(props.id, viewingFile.value.id, viewingFile.value.fileName, upload.value?.stream)
 })
+const isViewingVideo = computed(() => viewingFile.value && isVideoFile(viewingFile.value))
+const viewingVideoUrl = computed(() => {
+  if (!isViewingVideo.value) return ''
+  return getFileURL(props.id, viewingFile.value.id, viewingFile.value.fileName, upload.value?.stream)
+})
+const isViewingAudio = computed(() => viewingFile.value && isAudioFile(viewingFile.value))
+const viewingAudioUrl = computed(() => {
+  if (!isViewingAudio.value) return ''
+  return getFileURL(props.id, viewingFile.value.id, viewingFile.value.fileName, upload.value?.stream)
+})
 const renderedFileContent = computed(() => {
   if (!isViewingMarkdown.value || viewerTab.value !== 'preview') return ''
   if (!viewingContent.value) return ''
@@ -83,8 +93,8 @@ async function viewFile(file) {
   viewingLoading.value = false
   viewingError.value = null
 
-  // Images render directly from the server URL — no content fetch needed
-  if (isImageFile(file)) {
+  // Media files render directly from the server URL — no content fetch needed
+  if (isImageFile(file) || isVideoFile(file) || isAudioFile(file)) {
     nextTick(() => {
       document.getElementById('file-viewer-panel')?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
     })
@@ -657,6 +667,16 @@ watch(activeFiles, (files) => {
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                         d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
                 </svg>
+                <!-- Film icon for video files -->
+                <svg v-else-if="isViewingVideo" class="w-4 h-4 text-accent-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                        d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                </svg>
+                <!-- Music icon for audio files -->
+                <svg v-else-if="isViewingAudio" class="w-4 h-4 text-accent-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                        d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3" />
+                </svg>
                 <!-- Code icon for text files -->
                 <svg v-else class="w-4 h-4 text-accent-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -665,7 +685,7 @@ watch(activeFiles, (files) => {
                 <span class="text-sm font-medium text-surface-200">{{ viewingFile.fileName }}</span>
               </div>
               <div class="flex items-center gap-1">
-                <CopyButton v-if="viewingContent" :text="viewingContent" label="Copy" />
+                <CopyButton v-if="viewingContent && !isViewingVideo && !isViewingAudio" :text="viewingContent" label="Copy" />
                 <!-- Prev/Next navigation (only when multiple viewable files) -->
                 <template v-if="viewableFiles.length > 1">
                   <button class="p-1 transition-colors"
@@ -719,6 +739,20 @@ watch(activeFiles, (files) => {
               <img :src="viewingImageUrl"
                    :alt="viewingFile.fileName"
                    class="max-w-full max-h-[70vh] object-contain rounded" />
+            </div>
+            <div v-else-if="isViewingVideo" class="p-4 flex items-center justify-center bg-surface-900/50">
+              <video :key="viewingFile.id"
+                     :src="viewingVideoUrl"
+                     controls
+                     preload="metadata"
+                     class="max-w-full max-h-[70vh] rounded" />
+            </div>
+            <div v-else-if="isViewingAudio" class="p-4 flex items-center justify-center bg-surface-900/50">
+              <audio :key="viewingFile.id"
+                     :src="viewingAudioUrl"
+                     controls
+                     preload="metadata"
+                     class="w-full max-w-lg" />
             </div>
             <div v-else-if="!isViewingMarkdown" class="p-2">
               <CodeEditor


### PR DESCRIPTION
## Description

### What
Add native HTML5 `<video>` and `<audio>` inline playback to the download view file viewer, following the same pattern as the existing image viewer.

### Why
Uploaded video and audio files had no inline preview — users had to download them to play. Native browser elements provide play/pause/seek/volume/fullscreen with zero dependencies.

### Changes
- **utils.js**: `isVideoFile()`, `isAudioFile()` detection + updated `isViewableFile()`
- **DownloadView.vue**: computed refs, `viewFile()` short-circuit, `<video>`/`<audio>` rendering, header icons, hidden Copy button for media
- **utils.test.js**: 14 new tests (6 video + 6 audio + 2 viewable)
- **ARCHITECTURE.md**: documented video/audio playback section

### Testing
- All 154 unit tests pass
- Manual test: uploaded .mp4 video, confirmed single server request and inline playback