### PR TITLE
fix build instruction for 1.4.*

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ sudo systemctl start plikd
 
 # From source
 git clone https://github.com/root-gg/plik.git
-cd plik && make
+cd plik/webapp && npm install && cd ..
+make
 cd server && ./plikd
 
 # Kubernetes (Helm)


### PR DESCRIPTION
Webapp has to be built so that npm ci used by make can find package-lock.json file.

This small fix add the webapp build instruction