### PR TITLE
fix(s3): fix file deletion on versioned S3 buckets

### DIFF
--- a/docs/backends/data.md
+++ b/docs/backends/data.md
@@ -30,6 +30,11 @@ DataBackend = "s3"
     SendContentMd5 = false  # Use Content-MD5 instead of x-amz-checksum-* headers (for strict S3-compatible APIs like B2)
 ```
 
+### Bucket Versioning
+
+> [!WARNING]
+> Plik permanently deletes files from the S3 bucket, even if bucket versioning is enabled. Consider disabling versioning on your Plik bucket to avoid accumulating unnecessary delete markers.
+
 ### Server-Side Encryption
 
 | Mode | Description |

--- a/server/data/gcs/gcs_integration_test.go
+++ b/server/data/gcs/gcs_integration_test.go
@@ -1,0 +1,114 @@
+package gcs
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/stretchr/testify/require"
+
+	"github.com/root-gg/plik/server/common"
+)
+
+// newTestBackend creates a real GCS backend from PLIKD_CONFIG.
+// Skips the test if the config is absent or not a GCS backend.
+func newTestBackend(t *testing.T) *Backend {
+	t.Helper()
+
+	configPath := os.Getenv("PLIKD_CONFIG")
+	if configPath == "" {
+		t.Skip("PLIKD_CONFIG not set, skipping GCS integration test")
+	}
+
+	config, err := common.LoadConfiguration(configPath)
+	require.NoError(t, err, "unable to load config")
+
+	if config.DataBackend != "gcs" {
+		t.Skip("data backend is not gcs, skipping GCS integration test")
+	}
+
+	backend, err := NewBackend(NewConfig(config.DataBackendConfig))
+	require.NoError(t, err, "unable to create GCS backend")
+
+	return backend
+}
+
+// objectExists checks whether an object exists in GCS.
+func objectExists(t *testing.T, b *Backend, objectName string) bool {
+	t.Helper()
+	_, err := b.client.Bucket(b.Config.Bucket).Object(objectName).Attrs(context.Background())
+	if err != nil {
+		if err == storage.ErrObjectNotExist {
+			return false
+		}
+		t.Fatalf("unexpected GCS Attrs error: %s", err)
+	}
+	return true
+}
+
+func TestRemoveFileNewFormat(t *testing.T) {
+	b := newTestBackend(t)
+
+	upload := &common.Upload{}
+	file := upload.NewFile()
+	file.Status = common.FileUploaded
+	upload.InitializeForTests()
+
+	content := "test data for removal"
+	err := b.AddFile(file, bytes.NewBufferString(content))
+	require.NoError(t, err, "unable to add file")
+
+	// Verify the object exists at the storage level
+	objectName := b.getObjectName(file.UploadID, file.ID)
+	require.True(t, objectExists(t, b, objectName), "object should exist after AddFile")
+
+	// Verify we can read it back
+	reader, err := b.GetFile(file)
+	require.NoError(t, err, "unable to get file")
+	data, err := io.ReadAll(reader)
+	require.NoError(t, err, "unable to read file")
+	require.Equal(t, content, string(data), "file content mismatch")
+	_ = reader.Close()
+
+	// Remove the file
+	err = b.RemoveFile(file)
+	require.NoError(t, err, "unable to remove file")
+
+	// Verify the object is gone at the storage level
+	require.False(t, objectExists(t, b, objectName), "object should not exist after RemoveFile")
+}
+
+func TestRemoveFileTwice(t *testing.T) {
+	b := newTestBackend(t)
+
+	upload := &common.Upload{}
+	file := upload.NewFile()
+	file.Status = common.FileUploaded
+	upload.InitializeForTests()
+
+	err := b.AddFile(file, bytes.NewBufferString("data"))
+	require.NoError(t, err, "unable to add file")
+
+	err = b.RemoveFile(file)
+	require.NoError(t, err, "unable to remove file")
+
+	// Removing again should not error (interface contract)
+	err = b.RemoveFile(file)
+	require.NoError(t, err, "error removing already-removed file")
+}
+
+func TestRemoveFileNotFound(t *testing.T) {
+	b := newTestBackend(t)
+
+	upload := &common.Upload{}
+	file := upload.NewFile()
+	file.Status = common.FileUploaded
+	upload.InitializeForTests()
+
+	// File was never added — RemoveFile should not error
+	err := b.RemoveFile(file)
+	require.NoError(t, err, "error removing non-existent file")
+}

--- a/server/data/s3/s3.go
+++ b/server/data/s3/s3.go
@@ -178,28 +178,56 @@ func (b *Backend) newPutObjectOptions(contentType string) minio.PutObjectOptions
 
 // RemoveFile implementation for S3 Data Backend
 func (b *Backend) RemoveFile(file *common.File) (err error) {
-	// Try removing the new object name format first ({uploadID}.{fileID})
-	objectName := b.getObjectName(file.UploadID, file.ID)
-	err = b.client.RemoveObject(context.TODO(), b.config.Bucket, objectName, minio.RemoveObjectOptions{})
+	// Build stat options with server side encryption if configured
+	statOpts := minio.StatObjectOptions{}
+	statOpts.ServerSideEncryption, err = b.getServerSideEncryption(file)
 	if err != nil {
-		errResponse := minio.ToErrorResponse(err)
-		if errResponse.Code != "NoSuchKey" {
-			return fmt.Errorf("unable to remove s3 object %s : %s", objectName, err)
-		}
+		return err
+	}
 
-		// Fall back to legacy object name format ({fileID}) for backward compatibility
-		legacyName := b.getObjectNameLegacy(file.ID)
-		err = b.client.RemoveObject(context.TODO(), b.config.Bucket, legacyName, minio.RemoveObjectOptions{})
-		if err != nil {
-			errResponse = minio.ToErrorResponse(err)
-			if errResponse.Code == "NoSuchKey" {
-				return nil
-			}
-			return fmt.Errorf("unable to remove s3 object %s : %s", legacyName, err)
-		}
+	// Try new object name format first ({uploadID}.{fileID})
+	objectName := b.getObjectName(file.UploadID, file.ID)
+	removed, err := b.removeObject(objectName, statOpts)
+	if err != nil {
+		return fmt.Errorf("unable to remove s3 object %s : %s", objectName, err)
+	}
+	if removed {
+		return nil
+	}
+
+	// Fall back to legacy object name format ({fileID}) for backward compatibility
+	legacyName := b.getObjectNameLegacy(file.ID)
+	_, err = b.removeObject(legacyName, statOpts)
+	if err != nil {
+		return fmt.Errorf("unable to remove s3 object %s : %s", legacyName, err)
 	}
 
 	return nil
+}
+
+// removeObject checks if an object exists via StatObject, then removes it.
+// S3's DeleteObject API returns success even for non-existent objects,
+// so we must check existence first to know whether the object was actually found.
+// The VersionID from StatObject is passed to RemoveObject to ensure permanent
+// deletion on versioned buckets (otherwise only a delete marker is created).
+// Returns (true, nil) if removed, (false, nil) if not found, (false, err) on error.
+func (b *Backend) removeObject(objectName string, statOpts minio.StatObjectOptions) (removed bool, err error) {
+	info, err := b.client.StatObject(context.TODO(), b.config.Bucket, objectName, statOpts)
+	if err != nil {
+		errResponse := minio.ToErrorResponse(err)
+		if errResponse.Code == "NoSuchKey" {
+			return false, nil
+		}
+		return false, err
+	}
+
+	removeOpts := minio.RemoveObjectOptions{VersionID: info.VersionID}
+	err = b.client.RemoveObject(context.TODO(), b.config.Bucket, objectName, removeOpts)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
 }
 
 func (b *Backend) getObjectName(uploadID, fileID string) string {

--- a/server/data/s3/s3_integration_test.go
+++ b/server/data/s3/s3_integration_test.go
@@ -1,0 +1,184 @@
+package s3
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/stretchr/testify/require"
+
+	"github.com/root-gg/plik/server/common"
+)
+
+// newTestBackend creates a real S3 backend from PLIKD_CONFIG.
+// Skips the test if the config is absent or not an S3 backend.
+func newTestBackend(t *testing.T) *Backend {
+	t.Helper()
+
+	configPath := os.Getenv("PLIKD_CONFIG")
+	if configPath == "" {
+		t.Skip("PLIKD_CONFIG not set, skipping S3 integration test")
+	}
+
+	config, err := common.LoadConfiguration(configPath)
+	require.NoError(t, err, "unable to load config")
+
+	if config.DataBackend != "s3" {
+		t.Skip("data backend is not s3, skipping S3 integration test")
+	}
+
+	backend, err := NewBackend(NewConfig(config.DataBackendConfig))
+	require.NoError(t, err, "unable to create S3 backend")
+
+	return backend
+}
+
+// statObject is a test helper that checks whether an object exists in S3.
+func statObject(t *testing.T, b *Backend, objectName string) bool {
+	t.Helper()
+	_, err := b.client.StatObject(context.TODO(), b.config.Bucket, objectName, minio.StatObjectOptions{})
+	if err != nil {
+		errResponse := minio.ToErrorResponse(err)
+		if errResponse.Code == "NoSuchKey" {
+			return false
+		}
+		t.Fatalf("unexpected StatObject error: %s", err)
+	}
+	return true
+}
+
+func TestRemoveFileNewFormat(t *testing.T) {
+	b := newTestBackend(t)
+
+	upload := &common.Upload{}
+	file := upload.NewFile()
+	file.Status = common.FileUploaded
+	upload.InitializeForTests()
+
+	content := "test data for removal"
+	err := b.AddFile(file, bytes.NewBufferString(content))
+	require.NoError(t, err, "unable to add file")
+
+	// Verify the object exists at the storage level
+	objectName := b.getObjectName(file.UploadID, file.ID)
+	require.True(t, statObject(t, b, objectName), "object should exist after AddFile")
+
+	// Verify we can read it back
+	reader, err := b.GetFile(file)
+	require.NoError(t, err, "unable to get file")
+	data, err := io.ReadAll(reader)
+	require.NoError(t, err, "unable to read file")
+	require.Equal(t, content, string(data), "file content mismatch")
+	_ = reader.Close()
+
+	// Remove the file
+	err = b.RemoveFile(file)
+	require.NoError(t, err, "unable to remove file")
+
+	// Verify the object is gone at the storage level
+	require.False(t, statObject(t, b, objectName), "object should not exist after RemoveFile")
+}
+
+func TestRemoveFileLegacyFormat(t *testing.T) {
+	b := newTestBackend(t)
+
+	upload := &common.Upload{}
+	file := upload.NewFile()
+	file.Status = common.FileUploaded
+	upload.InitializeForTests()
+
+	content := "legacy test data"
+
+	// Manually upload with legacy naming ({fileID} only)
+	legacyName := b.getObjectNameLegacy(file.ID)
+	_, err := b.client.PutObject(
+		context.TODO(),
+		b.config.Bucket,
+		legacyName,
+		bytes.NewBufferString(content),
+		int64(len(content)),
+		b.newPutObjectOptions("application/octet-stream"),
+	)
+	require.NoError(t, err, "unable to put legacy object")
+
+	// Verify the legacy object exists
+	require.True(t, statObject(t, b, legacyName), "legacy object should exist")
+
+	// Verify the new-format key does NOT exist
+	newName := b.getObjectName(file.UploadID, file.ID)
+	require.False(t, statObject(t, b, newName), "new-format object should not exist")
+
+	// RemoveFile should fall back to the legacy name and delete it
+	err = b.RemoveFile(file)
+	require.NoError(t, err, "unable to remove file with legacy name")
+
+	// Verify the legacy object is gone
+	require.False(t, statObject(t, b, legacyName), "legacy object should not exist after RemoveFile")
+}
+
+func TestRemoveFileTwice(t *testing.T) {
+	b := newTestBackend(t)
+
+	upload := &common.Upload{}
+	file := upload.NewFile()
+	file.Status = common.FileUploaded
+	upload.InitializeForTests()
+
+	err := b.AddFile(file, bytes.NewBufferString("data"))
+	require.NoError(t, err, "unable to add file")
+
+	err = b.RemoveFile(file)
+	require.NoError(t, err, "unable to remove file")
+
+	// Removing again should not error (interface contract: "should not fail if the file is not found")
+	err = b.RemoveFile(file)
+	require.NoError(t, err, "error removing already-removed file")
+}
+
+func TestRemoveFileNotFound(t *testing.T) {
+	b := newTestBackend(t)
+
+	upload := &common.Upload{}
+	file := upload.NewFile()
+	file.Status = common.FileUploaded
+	upload.InitializeForTests()
+
+	// File was never added — RemoveFile should not error
+	err := b.RemoveFile(file)
+	require.NoError(t, err, "error removing non-existent file")
+}
+
+func TestRemoveFileWithPrefix(t *testing.T) {
+	b := newTestBackend(t)
+
+	if b.config.Prefix == "" {
+		t.Skip("S3 prefix not configured, skipping prefix test")
+	}
+
+	upload := &common.Upload{}
+	file := upload.NewFile()
+	file.Status = common.FileUploaded
+	upload.InitializeForTests()
+
+	content := "prefixed data"
+	err := b.AddFile(file, bytes.NewBufferString(content))
+	require.NoError(t, err, "unable to add file")
+
+	// Verify the object exists with the prefix
+	objectName := b.getObjectName(file.UploadID, file.ID)
+	require.Contains(t, objectName, b.config.Prefix+"/", "object name should contain prefix")
+	require.True(t, statObject(t, b, objectName), "prefixed object should exist")
+
+	// Without the prefix, object should not exist
+	bareObjectName := fmt.Sprintf("%s.%s", file.UploadID, file.ID)
+	require.False(t, statObject(t, b, bareObjectName), "bare object should not exist")
+
+	err = b.RemoveFile(file)
+	require.NoError(t, err, "unable to remove prefixed file")
+
+	require.False(t, statObject(t, b, objectName), "prefixed object should not exist after RemoveFile")
+}

--- a/server/data/swift/swift_integration_test.go
+++ b/server/data/swift/swift_integration_test.go
@@ -1,0 +1,116 @@
+package swift
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	goswift "github.com/ncw/swift"
+	"github.com/stretchr/testify/require"
+
+	"github.com/root-gg/plik/server/common"
+)
+
+// newTestBackend creates a real Swift backend from PLIKD_CONFIG.
+// Skips the test if the config is absent or not a Swift backend.
+func newTestBackend(t *testing.T) *Backend {
+	t.Helper()
+
+	configPath := os.Getenv("PLIKD_CONFIG")
+	if configPath == "" {
+		t.Skip("PLIKD_CONFIG not set, skipping Swift integration test")
+	}
+
+	config, err := common.LoadConfiguration(configPath)
+	require.NoError(t, err, "unable to load config")
+
+	if config.DataBackend != "swift" {
+		t.Skip("data backend is not swift, skipping Swift integration test")
+	}
+
+	backend := NewBackend(NewConfig(config.DataBackendConfig))
+
+	// Authenticate and ensure the container exists
+	err = backend.auth()
+	require.NoError(t, err, "unable to authenticate to Swift")
+
+	return backend
+}
+
+// objectExistsInSwift checks whether an object exists in the Swift container.
+func objectExistsInSwift(t *testing.T, b *Backend, objectName string) bool {
+	t.Helper()
+	_, _, err := b.connection.Object(b.config.Container, objectName)
+	if err != nil {
+		if err == goswift.ObjectNotFound {
+			return false
+		}
+		t.Fatalf("unexpected Swift Object error: %s", err)
+	}
+	return true
+}
+
+func TestRemoveFileNewFormat(t *testing.T) {
+	b := newTestBackend(t)
+
+	upload := &common.Upload{}
+	file := upload.NewFile()
+	file.Status = common.FileUploaded
+	upload.InitializeForTests()
+
+	content := "test data for removal"
+	err := b.AddFile(file, bytes.NewBufferString(content))
+	require.NoError(t, err, "unable to add file")
+
+	// Verify the object exists at the storage level
+	objName := objectID(file)
+	require.True(t, objectExistsInSwift(t, b, objName), "object should exist after AddFile")
+
+	// Verify we can read it back
+	reader, err := b.GetFile(file)
+	require.NoError(t, err, "unable to get file")
+	data, err := io.ReadAll(reader)
+	require.NoError(t, err, "unable to read file")
+	require.Equal(t, content, string(data), "file content mismatch")
+	_ = reader.Close()
+
+	// Remove the file
+	err = b.RemoveFile(file)
+	require.NoError(t, err, "unable to remove file")
+
+	// Verify the object is gone at the storage level
+	require.False(t, objectExistsInSwift(t, b, objName), "object should not exist after RemoveFile")
+}
+
+func TestRemoveFileTwice(t *testing.T) {
+	b := newTestBackend(t)
+
+	upload := &common.Upload{}
+	file := upload.NewFile()
+	file.Status = common.FileUploaded
+	upload.InitializeForTests()
+
+	err := b.AddFile(file, bytes.NewBufferString("data"))
+	require.NoError(t, err, "unable to add file")
+
+	err = b.RemoveFile(file)
+	require.NoError(t, err, "unable to remove file")
+
+	// Removing again should not error (interface contract)
+	err = b.RemoveFile(file)
+	require.NoError(t, err, "error removing already-removed file")
+}
+
+func TestRemoveFileNotFound(t *testing.T) {
+	b := newTestBackend(t)
+
+	upload := &common.Upload{}
+	file := upload.NewFile()
+	file.Status = common.FileUploaded
+	upload.InitializeForTests()
+
+	// File was never added — RemoveFile should not error
+	err := b.RemoveFile(file)
+	require.NoError(t, err, "error removing non-existent file")
+}

--- a/testing/ARCHITECTURE.md
+++ b/testing/ARCHITECTURE.md
@@ -45,6 +45,14 @@ DOCKER_VERSION="XXX" testing/test_backends.sh minio  # Specific docker image ver
 
 The actual test code lives in `plik/z*_e2e_*_test.go`. The `testing/` scripts provide the Docker infrastructure to run those same tests against real backends instead of the default in-memory backend. See [plik/ARCHITECTURE.md — E2E Test Suite](../plik/ARCHITECTURE.md#e2e-test-suite) for details on the test infrastructure, server bootstrapping, and what each test file covers.
 
+### Per-Backend Storage-Level Tests
+
+Each cloud data backend also has integration tests in its own package (`server/data/s3/`, `server/data/gcs/`, `server/data/swift/`) that verify objects are truly removed from the underlying storage after `RemoveFile`. These tests use `t.Skip` when `PLIKD_CONFIG` is not set or doesn't point to the matching backend. They run automatically during `make test` (skipping), and can be triggered with a real backend via:
+
+```bash
+PLIKD_CONFIG=testing/minio/plikd.cfg go test ./server/data/s3/... -v -race
+```
+
 ### Backend Coverage
 
 | Backend | Tests | Type |


### PR DESCRIPTION
## What

Fix S3 `RemoveFile` to properly delete objects from versioned S3-compatible
buckets (e.g. Backblaze B2 with "Keep all versions" enabled).

## Why

Two bugs in the previous implementation:

1. **Dead legacy fallback**: `DeleteObject` returns success even for non-existent
   keys, so the fallback from `{uploadID}.{fileID}` to legacy `{fileID}` naming
   never triggered.

2. **Versioned buckets**: `DeleteObject` without a `VersionID` only creates a
   delete marker — actual data persists indefinitely, silently accumulating
   storage costs.

## Changes

- **`server/data/s3/s3.go`** — Rewrite `RemoveFile` with a new `removeObject`
  helper that uses `StatObject` → `RemoveObject(VersionID)` flow. Forwards SSE
  options for SSE-C compatibility.
- **`server/data/s3/s3_integration_test.go`** — 5 new integration tests (new
  format, legacy fallback, idempotent, not found, prefix)
- **`server/data/gcs/gcs_integration_test.go`** — 3 new integration tests
- **`server/data/swift/swift_integration_test.go`** — 3 new integration tests
- **`docs/backends/data.md`** — Add versioning warning note
- **`testing/ARCHITECTURE.md`** — Document per-backend integration tests

## Testing

- `make lint` ✅
- `make test` ✅ (integration tests skip correctly without `PLIKD_CONFIG`)
- `make docs` ✅
- `make vuln` ✅
- S3 integration tests against Backblaze B2 with versioning ✅
- Server-level `TestClean` against B2 ✅
- Manual upload → `plikd file delete --all` → bucket empty ✅