### PR TITLE
Update gen_build_info.sh

### DIFF
--- a/server/gen_build_info.sh
+++ b/server/gen_build_info.sh
@@ -107,7 +107,7 @@ do
     fi
 	if [ -f "changelog/$gitTag" ]; then
 		# '%at': author date, UNIX timestamp
-		release_date=$(git show -s --pretty="format:%at" "refs/tags/$gitTag")
+		release_date=$(git show -s --pretty="format:%at" "refs/tags/$gitTag"|tail -n 1)
 		release_json="{\"name\": \"$gitTag\", \"date\": $release_date}"
 		releases+=("$release_json")
 	fi


### PR DESCRIPTION
Make it more robust to different git implementation. 

In my case, the binary panic because it can't parse the JSON output that was generated with the 'release_date' value : 

```
tag 1.4.0
Tagger: BAS <bas@794e82d1-a632-4471-899b-e5d22e1e190f.internal>

1.4.0

1772820956
```
which causes some issues at runtime.