### PR TITLE
fix(webapp): close file viewer when viewed file is deleted

### DIFF
--- a/webapp/e2e/download.spec.js
+++ b/webapp/e2e/download.spec.js
@@ -512,6 +512,28 @@ test.describe('Delete file/upload', () => {
         // File still visible
         await expect(page.getByRole('link', { name: 'cancel-delete.txt' })).toBeVisible()
     })
+
+    test('deleting viewed file closes viewer panel', async ({ page }) => {
+        // Upload a single text file — the viewer auto-opens for single viewable files
+        await uploadTestFile(page, 'viewed-file.txt', 'viewer content')
+        const panel = page.locator('#file-viewer-panel')
+        await expect(panel).toBeVisible({ timeout: 5_000 })
+
+        // Delete the file via the remove button
+        const removeBtn = page.getByTitle('Remove file').first()
+        await removeBtn.click()
+
+        // Confirm dialog
+        const dialog = page.locator('.fixed.inset-0.z-50 .glass-card')
+        await expect(dialog).toBeVisible({ timeout: 3_000 })
+        await dialog.getByRole('button', { name: 'Delete' }).click()
+
+        // Viewer panel should close
+        await expect(panel).not.toBeVisible({ timeout: 5_000 })
+
+        // Empty state should be shown
+        await expect(page.getByText('No files in this upload')).toBeVisible({ timeout: 5_000 })
+    })
 })
 
 test.describe('Unauthenticated download permissions', () => {

--- a/webapp/src/views/DownloadView.vue
+++ b/webapp/src/views/DownloadView.vue
@@ -237,6 +237,10 @@ async function deleteFile(file) {
           { id: props.id, stream: upload.value.stream, uploadToken: uploadToken.value },
           file,
         )
+        // Close viewer if the deleted file was being viewed
+        if (viewingFile.value?.id === file.id) {
+          closeViewer()
+        }
         await fetchUpload()
       } catch (err) {
         error.value = err.message || 'Failed to delete file'


### PR DESCRIPTION
## What
Close the file viewer panel when the user deletes the file currently being previewed.

## Why
After deleting the last (or currently-viewed) file, the viewer remained open showing stale content alongside the "No files in this upload" empty state.

## Changes
- **`DownloadView.vue`** — call `closeViewer()` in `deleteFile()` when the deleted file matches the viewed file
- **`download.spec.js`** — E2E test: upload a single file (auto-opens viewer), delete it, assert the viewer panel closes and the empty state appears

## Testing
- E2E test `'deleting viewed file closes viewer panel'` — passes
- Full `download.spec.js` suite — 30/30 passed
- Frontend unit tests — 154/154 passed
- Go lint — passes