### PR TITLE
feat(webapp): show removed/deleted files in download view and upload cards

### DIFF
--- a/webapp/ARCHITECTURE.md
+++ b/webapp/ARCHITECTURE.md
@@ -142,8 +142,8 @@ Files in the Plik API have a `status` field with 5 possible values:
 | `missing`   | File entry created, waiting to be uploaded         | ✅ Yes (uploading UI) |
 | `uploading` | File is currently being uploaded                   | ✅ Yes (progress bar) |
 | `uploaded`  | File has been uploaded and is ready for download   | ✅ Yes      |
-| `removed`   | File has been removed by user, not yet cleaned up  | ❌ No       |
-| `deleted`   | File has been deleted from the data backend        | ❌ No       |
+| `removed`   | File has been removed by user, not yet cleaned up  | ✅ Yes (greyed-out, "Removed" badge) |
+| `deleted`   | File has been deleted from the data backend        | ✅ Yes (greyed-out, "Removed" badge) |
 
 ### activeFiles computed property
 
@@ -151,13 +151,13 @@ During active uploads (`isAddingFiles`), the top panel only shows files the user
 - **Non-streaming**: only `uploaded` files (must be complete on server)
 - **Streaming**: `uploading` + `uploaded` (download works via live stream)
 
-When not uploading (e.g. friend viewing the download page), all non-removed files are shown:
+When not uploading (e.g. friend viewing the download page), all files are shown — including removed/deleted files, which render greyed-out with a "Removed" badge (no download/view/remove actions):
 
 ```js
 const activeFiles = computed(() => {
   if (!upload.value?.files) return []
   return upload.value.files.filter(f => {
-    if (f.status === 'removed' || f.status === 'deleted') return false
+    if (f.status === 'removed' || f.status === 'deleted') return true
     if (isAddingFiles.value) {
       if (upload.value.stream) {
         return f.status === 'uploading' || f.status === 'uploaded'
@@ -172,9 +172,11 @@ const activeFiles = computed(() => {
 
 > **Key design**: Files "move" from the bottom pending panel to the top active list as they become ready — non-streaming files appear when uploaded, streaming files appear when they start uploading (since their download link is immediately valid).
 
+> **Deleted file visibility**: Removed/deleted files stay visible in the file list with `opacity-50`, a red "Removed" pill badge, a `line-through` filename (plain text, no link), and all action buttons hidden. The `totalFiles` computed (which excludes removed/deleted) drives the heading count and the auto-view watcher, so "2 files" only counts downloadable files.
+
 > **Gotcha**: After deleting a file via the API, the server returns `"ok"` (plain text, not JSON). The file's status changes to `removed` server-side but the API **does not return the updated file object**. You must call `fetchUpload()` again to refresh the list.
 
-> **Note**: If `activeFiles.length === 0` after fetching, DownloadView shows a "No files in this upload" message. It does **not** redirect to home — this allows cancel-all and empty uploads to work cleanly.
+> **Note**: If all files are deleted, the file list still shows the greyed-out deleted rows. The "No files in this upload" empty state only appears when `activeFiles.length === 0` (i.e. no files at all, including deleted ones).
 
 ---
 
@@ -541,7 +543,7 @@ App.vue
 │   ├── CopyButton         — clipboard copy for tokens
 │   ├── EditUserModal      — shared edit-user modal (quotas, name, email, password)
 │   ├── UploadControls     — sort/order/badge filters with active-filters slot
-│   └── UploadCard         — shared upload card (files, tokens, actions)
+│   └── UploadCard         — shared upload card (files with status badges, tokens, actions)
 ├── AdminView.vue          — admin panel (stats/users/uploads)
 │   ├── ErrorBanner        — inline dismissible error banner
 │   ├── EditUserModal      — shared edit-user modal (quotas always shown)
@@ -878,7 +880,7 @@ For full details on the Docker multi-stage build and release packaging, see [rel
 
 3. **`uploadToken` must be in `X-UploadToken` header** — not in the request body or URL query for API calls.
 
-4. **During uploads, `activeFiles` filters by readiness** — non-streaming: only `uploaded`; streaming: `uploading` + `uploaded`. When not uploading (friend viewing), all non-removed statuses are shown. Don't change this to a simple blacklist.
+4. **During uploads, `activeFiles` filters by readiness** — non-streaming: only `uploaded`; streaming: `uploading` + `uploaded`. When not uploading (friend viewing), all files are shown including removed/deleted (greyed-out with "Removed" badge). The `totalFiles` computed excludes removed/deleted for counting purposes.
 
 5. **Refreshing the page loses admin access** — tokens are in-memory only. The only way to regain access is to open the Admin URL again.
 

--- a/webapp/e2e/download.spec.js
+++ b/webapp/e2e/download.spec.js
@@ -471,7 +471,7 @@ test.describe('Add files', () => {
 })
 
 test.describe('Delete file/upload', () => {
-    test('delete file removes it from list', async ({ page }) => {
+    test('delete file shows it as deleted', async ({ page }) => {
         // Upload two files so we can delete one
         await page.goto('/')
         await page.waitForLoadState('networkidle')
@@ -498,10 +498,35 @@ test.describe('Delete file/upload', () => {
         await expect(dialog).toBeVisible({ timeout: 3_000 })
         await dialog.getByRole('button', { name: 'Delete' }).click()
 
-        // File should disappear
-        await expect(page.getByRole('link', { name: 'remove.txt' })).not.toBeVisible({ timeout: 5_000 })
-        // Other file still there
+        // Deleted file should still be visible but greyed-out with a Deleted badge
+        await expect(page.getByText('Removed')).toBeVisible({ timeout: 5_000 })
+        // The file name should be plain text (no download link), with line-through
+        await expect(page.getByRole('link', { name: 'remove.txt' })).not.toBeVisible()
+        await expect(page.getByText('remove.txt')).toBeVisible()
+        // Other file still has its download link
         await expect(page.getByRole('link', { name: 'keep.txt' })).toBeVisible()
+        // File count heading should say "1 file" (only the live one)
+        await expect(page.getByRole('heading', { name: '1 file' })).toBeVisible({ timeout: 3_000 })
+    })
+
+    test('deleted file has no action buttons', async ({ page }) => {
+        await uploadTestFile(page, 'action-test.txt', 'action test content')
+
+        // Delete the file
+        const removeBtn = page.getByTitle('Remove file').first()
+        await removeBtn.click()
+        const dialog = page.locator('.fixed.inset-0.z-50 .glass-card')
+        await expect(dialog).toBeVisible({ timeout: 3_000 })
+        await dialog.getByRole('button', { name: 'Delete' }).click()
+
+        // Wait for the Deleted badge to appear
+        await expect(page.getByText('Removed')).toBeVisible({ timeout: 5_000 })
+
+        // No download, view, QR, copy, or remove buttons should be visible on the deleted row
+        await expect(page.getByRole('link', { name: 'Download' })).not.toBeVisible()
+        await expect(page.getByRole('button', { name: 'View' })).not.toBeVisible()
+        await expect(page.getByTitle('Show QR code')).not.toBeVisible()
+        await expect(page.getByTitle('Remove file')).not.toBeVisible()
     })
 
     test('delete upload redirects to home', async ({ page }) => {
@@ -555,8 +580,9 @@ test.describe('Delete file/upload', () => {
         // Viewer panel should close
         await expect(panel).not.toBeVisible({ timeout: 5_000 })
 
-        // Empty state should be shown
-        await expect(page.getByText('No files in this upload')).toBeVisible({ timeout: 5_000 })
+        // Deleted file should still be visible with Deleted badge (not hidden)
+        await expect(page.getByText('Removed')).toBeVisible({ timeout: 5_000 })
+        await expect(page.getByText('viewed-file.txt')).toBeVisible()
     })
 })
 

--- a/webapp/e2e/home.spec.js
+++ b/webapp/e2e/home.spec.js
@@ -146,6 +146,35 @@ test.describe('Home view', () => {
         // Token filter chip should be visible with the truncated token string
         await expect(page.getByText(tokenData.token.substring(0, 12))).toBeVisible({ timeout: 5_000 })
     })
+
+    test('upload card shows removed file with status badge', async ({ authenticatedPage: page }) => {
+        // Upload a file
+        await uploadTestFile(page, 'badge-test.txt', 'badge test content')
+
+        // Delete the file on the download page
+        const removeBtn = page.getByTitle('Remove file').first()
+        await removeBtn.click()
+        const dialog = page.locator('.fixed.inset-0.z-50 .glass-card')
+        await expect(dialog).toBeVisible({ timeout: 3_000 })
+        await dialog.getByRole('button', { name: 'Delete' }).click()
+        await expect(page.getByText('Removed')).toBeVisible({ timeout: 5_000 })
+
+        // Navigate to Home → Uploads tab
+        await page.goto('/#/home/uploads')
+        await page.waitForLoadState('networkidle')
+
+        // The file should appear with line-through styling (span, not link)
+        const fileName = page.locator('.line-through').filter({ hasText: 'badge-test.txt' })
+        await expect(fileName).toBeVisible({ timeout: 5_000 })
+
+        // The single-letter status badge (r or d) should be visible
+        const badge = page.locator('[title="Removed"], [title="Deleted"]')
+        await expect(badge).toBeVisible()
+        await expect(badge).toHaveText(/^[rd]$/)
+
+        // The file name should NOT be a download link
+        await expect(page.getByRole('link', { name: 'badge-test.txt' })).not.toBeVisible()
+    })
 })
 
 test.describe('User info card', () => {

--- a/webapp/src/components/FileRow.vue
+++ b/webapp/src/components/FileRow.vue
@@ -24,6 +24,10 @@ const isDownloadable = computed(() =>
   (props.isStream && props.file.status === 'uploading')
 )
 
+const isDeleted = computed(() =>
+  props.file.status === 'removed' || props.file.status === 'deleted'
+)
+
 const isViewable = computed(() => {
   if (props.file.status !== 'uploaded') return false
   return checkIsViewableFile(props.file)
@@ -83,7 +87,7 @@ function fileUrl() {
 </script>
 
 <template>
-  <div class="file-row animate-fade-in flex-wrap">
+  <div class="file-row animate-fade-in flex-wrap" :class="{ 'opacity-50': isDeleted }">
     <div class="flex flex-wrap items-center gap-2 md:gap-3 flex-1 min-w-0">
       <!-- File icon -->
       <div class="shrink-0">
@@ -126,7 +130,10 @@ function fileUrl() {
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
             </svg>
           </button>
-          <a v-if="isDownloadable && !isE2ee"
+          <span v-if="isDeleted" class="text-sm text-surface-500 truncate line-through">
+            {{ file.fileName }}
+          </span>
+          <a v-else-if="isDownloadable && !isE2ee"
              :href="fileUrl()"
              class="text-sm text-surface-200 hover:text-accent-400 transition-colors truncate"
              target="_blank"
@@ -191,18 +198,22 @@ function fileUrl() {
       </div>
 
       <!-- Status badge for non-uploaded files (download mode) -->
-      <span v-if="mode === 'download' && file.status === 'missing'"
+      <span v-if="mode === 'download' && isDeleted"
+            class="text-xs text-danger-500 bg-danger-500/10 px-2 py-0.5 rounded-full shrink-0">
+        Removed
+      </span>
+      <span v-else-if="mode === 'download' && file.status === 'missing'"
             class="text-xs text-warning-500 bg-warning-500/10 px-2 py-0.5 rounded-full shrink-0">
         Waiting for upload
       </span>
-      <span v-if="mode === 'download' && file.status === 'uploading'"
+      <span v-else-if="mode === 'download' && file.status === 'uploading'"
             class="text-xs text-accent-400 bg-accent-500/10 px-2 py-0.5 rounded-full shrink-0 inline-flex items-center gap-1">
         <div class="animate-spin rounded-full h-3 w-3 border border-accent-400 border-t-transparent" />
         Uploading…
       </span>
 
       <!-- Actions -->
-      <div class="flex items-center gap-1 shrink-0">
+      <div v-if="!isDeleted" class="flex items-center gap-1 shrink-0">
 
         <!-- QR Code button (download mode) -->
         <button v-if="mode === 'download' && isDownloadable"

--- a/webapp/src/components/UploadCard.vue
+++ b/webapp/src/components/UploadCard.vue
@@ -42,13 +42,32 @@ const emit = defineEmits(['delete', 'filter-token', 'filter-user'])
 
       <!-- Files -->
       <div class="flex-1 min-w-0 text-sm space-y-1">
-        <div v-for="file in (upload.files || []).filter(f => f.status === 'uploaded')"
+        <div v-for="file in (upload.files || [])"
              :key="file.id"
-             class="flex items-center justify-between gap-2">
-          <a :href="getFileURL(upload.id, file.id, file.fileName, upload.stream)"
-             class="text-surface-300 hover:text-accent-400 transition-colors truncate">
-            {{ file.fileName }}
-          </a>
+             class="flex items-center justify-between gap-2"
+             :class="{ 'opacity-50': file.status !== 'uploaded' }">
+          <div class="flex items-center gap-1.5 min-w-0">
+            <span v-if="file.status === 'missing'"
+                  class="shrink-0 w-4 h-4 rounded-full bg-warning-500/15 text-warning-500 text-[10px] font-bold flex items-center justify-center cursor-default"
+                  title="Missing — waiting for upload">m</span>
+            <span v-else-if="file.status === 'uploading'"
+                  class="shrink-0 w-4 h-4 rounded-full bg-accent-500/15 text-accent-400 text-[10px] font-bold flex items-center justify-center cursor-default"
+                  title="Uploading">u</span>
+            <span v-else-if="file.status === 'removed'"
+                  class="shrink-0 w-4 h-4 rounded-full bg-danger-500/15 text-danger-500 text-[10px] font-bold flex items-center justify-center cursor-default"
+                  title="Removed">r</span>
+            <span v-else-if="file.status === 'deleted'"
+                  class="shrink-0 w-4 h-4 rounded-full bg-danger-500/15 text-danger-500 text-[10px] font-bold flex items-center justify-center cursor-default"
+                  title="Deleted">d</span>
+            <a v-else-if="file.status === 'uploaded'"
+               :href="getFileURL(upload.id, file.id, file.fileName, upload.stream)"
+               class="text-surface-300 hover:text-accent-400 transition-colors truncate">
+              {{ file.fileName }}
+            </a>
+            <span v-else class="text-surface-500 truncate line-through">
+              {{ file.fileName }}
+            </span>
+          </div>
           <span class="text-surface-500 shrink-0">{{ humanReadableSize(file.fileSize) }}</span>
         </div>
         <p v-if="!upload.files || upload.files.length === 0"

--- a/webapp/src/views/DownloadView.vue
+++ b/webapp/src/views/DownloadView.vue
@@ -164,11 +164,11 @@ function onViewerKeydown(e) {
 // During uploads, only show files the user can interact with:
 //  - Non-streaming: only 'uploaded' (file complete on server)
 //  - Streaming: 'uploading' + 'uploaded' (download works via live stream)
-// When not uploading (e.g. friend viewing), show all non-removed files
+// When not uploading (e.g. friend viewing), show all files including removed/deleted
 const activeFiles = computed(() => {
   if (!upload.value?.files) return []
   return upload.value.files.filter(f => {
-    if (f.status === 'removed' || f.status === 'deleted') return false
+    if (f.status === 'removed' || f.status === 'deleted') return true
     if (isAddingFiles.value) {
       if (upload.value.stream) {
         return f.status === 'uploading' || f.status === 'uploaded'
@@ -184,6 +184,12 @@ const activeFiles = computed(() => {
 const totalFiles = computed(() => {
   if (!upload.value?.files) return 0
   return upload.value.files.filter(f => f.status !== 'removed' && f.status !== 'deleted').length
+})
+
+// Count of fully uploaded files (progress numerator during active uploads)
+const uploadedCount = computed(() => {
+  if (!upload.value?.files) return 0
+  return upload.value.files.filter(f => f.status === 'uploaded').length
 })
 
 // Upload token from in-memory store (set after upload or from admin URL)
@@ -813,10 +819,10 @@ watch(activeFiles, (files) => {
             <div class="flex items-center justify-between px-1">
               <h3 class="text-sm font-medium text-surface-400">
                 <template v-if="isAddingFiles && !upload.stream">
-                  {{ activeFiles.length }}/{{ totalFiles }} file{{ totalFiles > 1 ? 's' : '' }} uploaded
+                  {{ uploadedCount }}/{{ totalFiles }} file{{ totalFiles > 1 ? 's' : '' }} uploaded
                 </template>
                 <template v-else>
-                  {{ activeFiles.length }} file{{ activeFiles.length > 1 ? 's' : '' }}
+                  {{ totalFiles }} file{{ totalFiles > 1 ? 's' : '' }}
                 </template>
               </h3>
               <CopyButton


### PR DESCRIPTION
## Description

### What

Make removed/deleted files visible across the webapp instead of hiding them. The server's `GetUpload` API already returns files in all statuses — this change is purely frontend.

**Download View** (`FileRow.vue` + `DownloadView.vue`):
- Removed files stay in the list with `opacity-50`, a red "Removed" pill badge, `line-through` filename (plain text, no link), and all action buttons hidden
- File count heading uses `totalFiles` (excludes removed/deleted) so "2 files" reflects only downloadable files
- Removed/deleted files pass through `activeFiles` even during active uploads, so deleting a file mid-upload shows it as greyed-out instead of vanishing
- Dedicated `uploadedCount` computed drives the progress fraction ("1/4 files uploaded") for accuracy

**Upload Cards** (`UploadCard.vue` in Home/Admin):
- All file statuses now visible with single-letter colored circle badges and hover tooltips:
  - **m** (warning) — Missing — waiting for upload
  - **u** (accent) — Uploading
  - **r** (danger) — Removed
  - **d** (danger) — Deleted
- Non-uploaded files shown with `line-through` and `opacity-50`

### Why

Previously, deleted files simply vanished from the UI with no trace. Users visiting a download page had no way to know files were once there. This change makes the upload history transparent to all viewers.

### Changes

**Components:**
- `FileRow.vue` — `isDeleted` computed, "Removed" badge, greyed-out styling, hidden actions
- `UploadCard.vue` — show all files, single-letter badges with tooltips, strikethrough for non-uploaded
- `DownloadView.vue` — removed `removed`/`deleted` filter from `activeFiles`; added early-return for removed/deleted during uploads so they stay visible mid-upload; added `uploadedCount` computed for accurate progress fraction; heading uses `totalFiles` for download-mode count

**Tests:**
- `download.spec.js` — updated 2 tests + 1 new (`deleted file has no action buttons`)
- `home.spec.js` — 1 new test (`upload card shows removed file with status badge`)

**Docs:**
- `ARCHITECTURE.md` — updated file status table, `activeFiles` code block, component tree, pitfall #4

### Testing

- `make lint` — ✅
- `make frontend` — ✅ build passes
- `make test-frontend` — ✅ 147 unit tests pass
- `npx playwright test e2e/download.spec.js e2e/home.spec.js` — ✅ 50 E2E tests pass
- Manual verification: uploaded multiple files, deleted some mid-upload, confirmed correct counter and greyed-out rows
- No server-side changes needed