### PR TITLE
fix(webapp): prevent navbar overflow on medium viewports

### DIFF
--- a/webapp/src/components/AppHeader.vue
+++ b/webapp/src/components/AppHeader.vue
@@ -36,7 +36,7 @@ watch(() => route.fullPath, () => { mobileOpen.value = false })
       </router-link>
 
       <!-- Nav Links (desktop) -->
-      <nav class="hidden sm:flex items-center gap-1">
+      <nav class="hidden lg:flex items-center gap-1">
         <router-link to="/" class="btn-ghost text-sm">
           <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -129,7 +129,7 @@ watch(() => route.fullPath, () => { mobileOpen.value = false })
       </nav>
 
       <!-- Mobile menu button -->
-      <button class="sm:hidden btn-ghost p-2" @click="mobileOpen = !mobileOpen">
+      <button class="lg:hidden btn-ghost p-2" @click="mobileOpen = !mobileOpen">
         <!-- Hamburger / X icon -->
         <svg v-if="!mobileOpen" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
@@ -142,7 +142,7 @@ watch(() => route.fullPath, () => { mobileOpen.value = false })
 
     <!-- Mobile dropdown menu -->
     <nav v-if="mobileOpen"
-         class="sm:hidden border-t border-surface-700/50 bg-surface-900/95 backdrop-blur-md animate-fade-in">
+         class="lg:hidden border-t border-surface-700/50 bg-surface-900/95 backdrop-blur-md animate-fade-in">
       <div class="px-4 py-3 space-y-1">
         <router-link to="/"
                      class="flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm text-surface-200
@@ -199,7 +199,7 @@ watch(() => route.fullPath, () => { mobileOpen.value = false })
             <span>Theme</span>
           </ThemePicker>
         </template>
-        <div v-if="showThemePicker || isFeatureEnabled('authentication')" class="border-t border-surface-700/50 my-1"></div>
+        <div v-if="isFeatureEnabled('authentication')" class="border-t border-surface-700/50 my-1"></div>
 
         <router-link v-if="auth.user"
                      to="/home"


### PR DESCRIPTION
### What
Fixes responsive navbar issues in `AppHeader.vue`:
1. Bumps the desktop nav breakpoint from `sm` (640px) to `lg` (1024px) — below 1024px the hamburger mobile menu takes over.
2. Removes a trailing separator after the Theme picker in the mobile menu when authentication is disabled.

### Why
- On medium viewports (640–1024px), the horizontal nav items overflowed the header, making the rightmost items unreachable.
- When authentication is disabled, a useless `border-t` divider rendered below Theme with no items after it.

### Changes
- `hidden sm:flex` → `hidden lg:flex` on the desktop nav container
- `sm:hidden` → `lg:hidden` on the hamburger button and mobile dropdown
- Mobile separator condition: `showThemePicker || isFeatureEnabled('authentication')` → `isFeatureEnabled('authentication')` (matches the desktop nav separator)

### Testing
- Frontend build passes
- 147 unit tests pass