### PR TITLE
fix(helm): add missing serviceaccount.yaml template

### DIFF
--- a/charts/plik/ARCHITECTURE.md
+++ b/charts/plik/ARCHITECTURE.md
@@ -18,6 +18,7 @@ charts/plik/
     ├── _helpers.tpl            ← Template helpers (plik.fullname, plik.secretName, etc.)
     ├── configmap.yaml          ← Renders plikd.cfg from non-sensitive plikd.* values
     ├── secret.yaml             ← Renders Kubernetes Secret from secrets.* values
+    ├── serviceaccount.yaml     ← Optional ServiceAccount (when serviceAccount.create is true)
     ├── deployment.yaml         ← Deployment or StatefulSet (controlled by .Values.kind)
     ├── service.yaml            ← ClusterIP service on port 8080
     ├── ingress.yaml            ← Optional Ingress resource

--- a/charts/plik/CHANGELOG.md
+++ b/charts/plik/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Add missing `serviceaccount.yaml` template — `serviceAccount.create: true` now correctly creates a ServiceAccount resource
+
+### Added
+- New `serviceAccount.automount` value to control `automountServiceAccountToken` on the ServiceAccount (default: `false`)
+
 ## [1.4.2]
 
 ### Added

--- a/charts/plik/README.md
+++ b/charts/plik/README.md
@@ -180,6 +180,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for design decisions around config vs. se
 | service.port | int | `8080` | Service port |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.automount | bool | `false` | Automatically mount the service account token |
 | serviceAccount.create | bool | `false` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | tolerations | list | `[]` | Tolerations for pod scheduling |

--- a/charts/plik/templates/serviceaccount.yaml
+++ b/charts/plik/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "plik.serviceAccountName" . }}
+  labels:
+    {{- include "plik.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount | default false }}
+{{- end }}

--- a/charts/plik/values.yaml
+++ b/charts/plik/values.yaml
@@ -23,6 +23,8 @@ fullnameOverride: ""
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: false
+  # -- Automatically mount the service account token
+  automount: false
   # -- Annotations to add to the service account
   annotations: {}
   # -- The name of the service account to use.


### PR DESCRIPTION
Fixes #743

## What

Add the missing `serviceaccount.yaml` template so that `serviceAccount.create: true` actually creates a ServiceAccount resource.

## Why

The chart has `serviceAccount.create` in values and a `plik.serviceAccountName` helper in `_helpers.tpl`, but no template to create the SA. Setting `create: true` causes the Deployment to reference a non-existent SA, failing pod creation.

## Changes

- **New**: `charts/plik/templates/serviceaccount.yaml` — standard Helm SA template
- **Updated**: `charts/plik/values.yaml` — added `serviceAccount.automount` field (default: `false`)
- **Updated**: `charts/plik/CHANGELOG.md` — added fix to `[Unreleased]`
- **Updated**: `charts/plik/ARCHITECTURE.md` — added `serviceaccount.yaml` to structure listing
- **Regenerated**: `charts/plik/README.md` via `make helm-docs`

## Testing

### Bug reproduction (Kind cluster, chart v1.4.2)

```bash
kind create cluster --name plik-test
helm install plik plik/plik --version 1.4.2 \
  --namespace plik-test --create-namespace \
  --set serviceAccount.create=true
kubectl -n plik-test describe replicaset -l app.kubernetes.io/name=plik
```

**Result**: Pods fail with `error looking up service account plik-test/plik: serviceaccount "plik" not found`

### Fix verification (Kind cluster, local chart)

```bash
helm package charts/plik --destination /tmp/
helm install plik /tmp/plik-*.tgz \
  --namespace plik-test --create-namespace \
  --set serviceAccount.create=true
kubectl -n plik-test wait --for=condition=available deployment/plik --timeout=120s
```

**Result**: ✅ Deployment available, pods running, ServiceAccount created

### Functional verification (CLI smoke test against Kind deployment)

```bash
make client
kubectl -n plik-test port-forward svc/plik 18080:8080 &
echo "test file" > /tmp/plik-test.txt
client/plik --server http://localhost:18080 /tmp/plik-test.txt
curl -s "<download-url>"
```

**Result**: ✅ File uploaded and downloaded successfully

### Template verification

```bash
# With create=true: SA resource rendered
helm template plik charts/plik --set serviceAccount.create=true | grep "kind: ServiceAccount"
# ✅ ServiceAccount rendered

# With create=false (default): uses "default" SA
helm template plik charts/plik | grep serviceAccountName
# ✅ serviceAccountName: default
```

### Project tests

```bash
make lint       # ✅ go fmt + go vet + go fix passed
make test       # ✅ all tests passed (server, e2e, handlers, metadata, middleware, crypto)
make helm-docs  # ✅ README.md up to date
make helm       # ✅ chart packages correctly
```

## Environment

- Kubernetes: 1.33.8 (AKS), 1.35.0 (Kind v0.31.0)
- Helm: 4.1.4
- Go: 1.26.2
- Chart: 1.4.2