### PR TITLE
feat(helm): add extraObjects support to deploy supplementary resources

### DIFF
--- a/charts/plik/ARCHITECTURE.md
+++ b/charts/plik/ARCHITECTURE.md
@@ -23,6 +23,7 @@ charts/plik/
     ├── service.yaml            ← ClusterIP service on port 8080
     ├── ingress.yaml            ← Optional Ingress resource
     ├── pvc.yaml                ← PVC for file/db data (when persistence/dbPersistence enabled)
+    ├── extra-objects.yaml      ← Renders arbitrary extra Kubernetes manifests (extraObjects)
     └── NOTES.txt               ← Post-install instructions
 ```
 
@@ -56,3 +57,18 @@ Both default to `emptyDir` when disabled. For `StatefulSet` mode, volumes use `v
 ### Versioning
 
 Chart `version` and `appVersion` in `Chart.yaml` use `__VERSION__` placeholders, replaced at release time by `releaser/helm_release.sh` to match the app release tag.
+
+### extraObjects — deploying supplementary resources
+
+`extraObjects` allows users to deploy arbitrary Kubernetes manifests alongside the chart (e.g. ExternalSecrets, NetworkPolicies, RBAC rules). It supports three forms to accommodate different values file strategies:
+
+| Form | Value type | Multi-file merge | tpl support | When to use |
+|------|-----------|-----------------|-------------|-------------|
+| **Dict** | `extraObjects: {key: {...}}` | ✅ Helm deep-merges dicts | ✅ Yes | **Recommended** — each `-f` file adds its own named key independently |
+| **List** | `extraObjects: [...]` | ❌ Last file wins | ✅ Yes | Single values file |
+| **String** | `extraObjects: \|` | ❌ Last file wins | ✅ Yes (whole block evaluated first) | Inline Go template expressions |
+
+The dict form is the default (`extraObjects: {}`) because Helm performs a deep merge on maps across multiple `-f` files, whereas lists and strings are always fully replaced by the last file. Each dict key is an arbitrary label used only to allow merging — only the value (the manifest) is rendered.
+
+All forms pass manifests through `tpl` before rendering, so Go template helpers such as `{{ include "plik.fullname" . }}` and `{{ .Release.Name }}` work in all cases.
+

--- a/charts/plik/CHANGELOG.md
+++ b/charts/plik/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - New `serviceAccount.automount` value to control `automountServiceAccountToken` on the ServiceAccount (default: `false`)
+- New `extraObjects` value to deploy arbitrary extra Kubernetes manifests alongside the chart (e.g. ExternalSecrets, NetworkPolicies, RBAC rules). Supports three forms: **dict** (recommended — Helm deep-merges dicts across multiple `-f` files, so each file can add its own key independently), **list** (single values file), or **string** (supports inline Go template expressions). All forms support `tpl`.
 
 ## [1.4.2]
 

--- a/charts/plik/README.md
+++ b/charts/plik/README.md
@@ -85,6 +85,7 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for design decisions around config vs. se
 | dbPersistence.enabled | bool | `false` | Enable persistent storage for the SQLite database |
 | dbPersistence.path | string | `"/home/plik/server/db"` | Mount path for the database inside the container |
 | dbPersistence.size | string | `"1Gi"` | PVC storage size |
+| extraObjects | object | `{}` | Extra Kubernetes manifests to deploy alongside the chart. Accepts dict (recommended), list, or string. See ARCHITECTURE.md. |
 | fullnameOverride | string | `""` | Override the full release name |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"rootgg/plik"` | Docker image repository |

--- a/charts/plik/templates/extra-objects.yaml
+++ b/charts/plik/templates/extra-objects.yaml
@@ -1,0 +1,58 @@
+{{- /*
+extra-objects.yaml — Renders arbitrary extra Kubernetes manifests supplied by the user.
+
+extraObjects supports three forms:
+
+  Form 1 — dict (recommended for multi-file values override):
+    Helm deep-merges dicts across -f files, so each file can add its own named
+    key without overwriting keys from other files. Dict values are rendered via tpl.
+
+    extraObjects:
+      my-secret:
+        apiVersion: v1
+        kind: Secret
+        ...
+
+  Form 2 — list:
+    Convenient for a single values file. A second -f file replaces the entire list.
+    Each item is rendered via tpl.
+
+    extraObjects:
+      - apiVersion: v1
+        kind: ConfigMap
+        ...
+
+  Form 3 — string:
+    Same last-file-wins behaviour as a list. The whole string is rendered via tpl
+    first, then parsed as YAML — useful for inline Go template expressions.
+
+    extraObjects: |
+      - apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: {{ include "plik.fullname" . }}-extra
+        ...
+*/ -}}
+{{- if .Values.extraObjects }}
+{{- if kindIs "string" .Values.extraObjects }}
+{{- /* Form 3: string — render the whole block with tpl, then parse as YAML array */}}
+{{- range (tpl .Values.extraObjects $ | fromYamlArray) }}
+---
+{{ toYaml . }}
+{{- end }}
+{{- else if kindIs "map" .Values.extraObjects }}
+{{- /* Form 1: dict — iterate over values; keys are used only as labels for merging */}}
+{{- range $key, $obj := .Values.extraObjects }}
+---
+{{ tpl (toYaml $obj) $ }}
+{{- end }}
+{{- else }}
+{{- /* Form 2: list */}}
+{{- range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+

--- a/charts/plik/values.yaml
+++ b/charts/plik/values.yaml
@@ -347,3 +347,53 @@ secrets:
   # Injected as `PLIKD_METADATA_BACKEND_CONFIG` JSON.
   metadataBackend: {}
   #   Password: ""
+
+# -- Extra Kubernetes objects to deploy alongside the chart.
+# Supports three forms — choose based on your values file strategy:
+#
+# ── Form 1: dict (recommended when using multiple values files) ────────────────
+# Helm performs a deep merge on dicts, so each values file can add its own key
+# without overwriting keys defined in other files.
+#
+# extraObjects:
+#   my-external-secret:
+#     apiVersion: external-secrets.io/v1beta1
+#     kind: ExternalSecret
+#     metadata:
+#       name: plik-external-secret
+#     spec:
+#       secretStoreRef:
+#         name: my-store
+#         kind: ClusterSecretStore
+#       target:
+#         name: plik-secret
+#       data:
+#         - secretKey: PLIKD_GOOGLE_API_SECRET
+#           remoteRef:
+#             key: plik/google-api-secret
+#
+# ── Form 2: list (simple, single values file) ─────────────────────────────────
+# Convenient when everything is in one file. Note: a second -f file will replace
+# the entire list, not append to it.
+#
+# extraObjects:
+#   - apiVersion: v1
+#     kind: ConfigMap
+#     metadata:
+#       name: my-extra-config
+#     data:
+#       foo: bar
+#
+# ── Form 3: string (alternative to list for single-file use) ──────────────────
+# Same merge behaviour as a list (last file wins), but Go template expressions
+# are supported inline (e.g. {{ include "plik.fullname" . }}).
+#
+# extraObjects: |
+#   - apiVersion: v1
+#     kind: ConfigMap
+#     metadata:
+#       name: {{ include "plik.fullname" . }}-extra
+#     data:
+#       foo: bar
+extraObjects: {}
+

--- a/charts/plik/values.yaml
+++ b/charts/plik/values.yaml
@@ -348,52 +348,53 @@ secrets:
   metadataBackend: {}
   #   Password: ""
 
-# -- Extra Kubernetes objects to deploy alongside the chart.
 # Supports three forms — choose based on your values file strategy:
 #
-# ── Form 1: dict (recommended when using multiple values files) ────────────────
+# Form 1: dict (recommended when using multiple values files)
 # Helm performs a deep merge on dicts, so each values file can add its own key
 # without overwriting keys defined in other files.
 #
-# extraObjects:
-#   my-external-secret:
-#     apiVersion: external-secrets.io/v1beta1
-#     kind: ExternalSecret
-#     metadata:
-#       name: plik-external-secret
-#     spec:
-#       secretStoreRef:
-#         name: my-store
-#         kind: ClusterSecretStore
-#       target:
-#         name: plik-secret
-#       data:
-#         - secretKey: PLIKD_GOOGLE_API_SECRET
-#           remoteRef:
-#             key: plik/google-api-secret
+#   extraObjects:
+#     my-external-secret:
+#       apiVersion: external-secrets.io/v1beta1
+#       kind: ExternalSecret
+#       metadata:
+#         name: plik-external-secret
+#       spec:
+#         secretStoreRef:
+#           name: my-store
+#           kind: ClusterSecretStore
+#         target:
+#           name: plik-secret
+#         data:
+#           - secretKey: PLIKD_GOOGLE_API_SECRET
+#             remoteRef:
+#               key: plik/google-api-secret
 #
-# ── Form 2: list (simple, single values file) ─────────────────────────────────
+# Form 2: list (simple, single values file)
 # Convenient when everything is in one file. Note: a second -f file will replace
 # the entire list, not append to it.
 #
-# extraObjects:
-#   - apiVersion: v1
-#     kind: ConfigMap
-#     metadata:
-#       name: my-extra-config
-#     data:
-#       foo: bar
+#   extraObjects:
+#     - apiVersion: v1
+#       kind: ConfigMap
+#       metadata:
+#         name: my-extra-config
+#       data:
+#         foo: bar
 #
-# ── Form 3: string (alternative to list for single-file use) ──────────────────
+# Form 3: string (alternative to list for single-file use)
 # Same merge behaviour as a list (last file wins), but Go template expressions
 # are supported inline (e.g. {{ include "plik.fullname" . }}).
 #
-# extraObjects: |
-#   - apiVersion: v1
-#     kind: ConfigMap
-#     metadata:
-#       name: {{ include "plik.fullname" . }}-extra
-#     data:
-#       foo: bar
+#   extraObjects: |
+#     - apiVersion: v1
+#       kind: ConfigMap
+#       metadata:
+#         name: {{ include "plik.fullname" . }}-extra
+#       data:
+#         foo: bar
+
+# -- (object) Extra Kubernetes manifests to deploy alongside the chart. Accepts dict (recommended), list, or string. See ARCHITECTURE.md.
 extraObjects: {}
 


### PR DESCRIPTION
Add a new `extraObjects` value to the Plik Helm chart, allowing users to deploy arbitrary Kubernetes manifests alongside the chart (e.g. ExternalSecrets, NetworkPolicies, RBAC rules).
Three input forms are supported via `templates/extra-objects.yaml`:
- dict (default, recommended): Helm deep-merges dicts across multiple `-f` files, so each values file can independently add its own named key without overwriting keys from other files.
- list: convenient for a single values file; a second `-f` replaces the entire list.
- string: same last-file-wins behaviour as a list, but the whole block is evaluated through `tpl` first — useful for inline Go template expressions (e.g. `{{ include "plik.fullname" . }}`). All three forms pass manifests through `tpl` before rendering. Update ARCHITECTURE.md with a comparison table and CHANGELOG.md with an [Unreleased] entry.