### PR TITLE
fix(cli): identify OIDC users by their real ID in user/token commands

### DIFF
--- a/docs/operations/server-cli.md
+++ b/docs/operations/server-cli.md
@@ -42,6 +42,14 @@ plikd user create --login bob --max-file-size 100MB --max-user-size 1GB --max-tt
 plikd user list
 ```
 
+::: tip OIDC users
+OIDC users are identified by their `sub` claim, not by their username. `plikd user list` prints the real ID (e.g. `oidc:8f9d056a-1dab-3192-f1ae-552e024d948e`) followed by the username — pass the full ID part after `oidc:` as `--login` to `show`, `update`, `delete` and `token` commands:
+
+```bash
+plikd user update --provider oidc --login 8f9d056a-1dab-3192-f1ae-552e024d948e --admin
+```
+:::
+
 ### Show user details
 
 ```bash

--- a/server/cmd/token.go
+++ b/server/cmd/token.go
@@ -88,7 +88,7 @@ func createToken(cmd *cobra.Command, args []string) {
 	}
 
 	if user == nil {
-		fmt.Printf("User %s not found\n", userID)
+		fmt.Println(userNotFoundError(tokenParams.provider, userID))
 		os.Exit(1)
 	}
 

--- a/server/cmd/user.go
+++ b/server/cmd/user.go
@@ -107,6 +107,17 @@ func init() {
 	userCmd.AddCommand(deleteUserCmd)
 }
 
+// userNotFoundError returns the message shown when a user lookup fails.
+// OIDC users are keyed by the sub claim, not by their displayed login,
+// so hint at how to find the right identifier.
+func userNotFoundError(provider string, userID string) string {
+	msg := fmt.Sprintf("User %s not found", userID)
+	if provider == common.ProviderOIDC {
+		msg += "\nOIDC users are identified by their 'sub' claim : run 'plikd user list' and pass the ID part after 'oidc:' as --login"
+	}
+	return msg
+}
+
 // parseMaxSize parses a human-readable byte size flag value.
 // Returns -1 for unlimited, 0 for unset, or the parsed byte count.
 func parseMaxSize(flagName string, s string) int64 {
@@ -225,7 +236,7 @@ func showUser(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 	if user == nil {
-		fmt.Printf("User %s not found\n", userID)
+		fmt.Println(userNotFoundError(userParams.provider, userID))
 		os.Exit(1)
 	}
 
@@ -257,7 +268,7 @@ func updateUser(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 	if user == nil {
-		fmt.Printf("User %s not found\n", userID)
+		fmt.Println(userNotFoundError(userParams.provider, userID))
 		os.Exit(1)
 	}
 
@@ -366,7 +377,7 @@ func deleteUser(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 	if user == nil {
-		fmt.Printf("user %s not found\n", userID)
+		fmt.Println(userNotFoundError(userParams.provider, userID))
 		os.Exit(1)
 	}
 

--- a/server/cmd/user_test.go
+++ b/server/cmd/user_test.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/root-gg/plik/server/common"
+)
+
+func TestUserNotFoundError(t *testing.T) {
+	// Non-OIDC providers get a plain message.
+	msg := userNotFoundError(common.ProviderLocal, "local:admin")
+	require.Equal(t, "User local:admin not found", msg)
+
+	// OIDC users are keyed by the sub claim, so the message must hint at how
+	// to find the right identifier.
+	msg = userNotFoundError(common.ProviderOIDC, "oidc:test_user")
+	require.Contains(t, msg, "User oidc:test_user not found")
+	require.Contains(t, msg, "sub")
+	require.Contains(t, msg, "plikd user list")
+}

--- a/server/common/user.go
+++ b/server/common/user.go
@@ -73,9 +73,18 @@ func (user *User) NewToken() (token *Token) {
 	return token
 }
 
-// NewToken add a new token to a user
+// String returns the user ID (as expected by the CLI --login flag) followed by
+// the login when it differs from the ID (OIDC users are keyed by the sub claim
+// while their login holds the preferred username), then name and email.
 func (user *User) String() string {
-	str := user.Provider + ":" + user.Login
+	id := user.ID
+	if id == "" {
+		id = GetUserID(user.Provider, user.Login)
+	}
+	str := id
+	if id != GetUserID(user.Provider, user.Login) {
+		str += " " + user.Login
+	}
 	if user.Name != "" {
 		str += " " + user.Name
 	}

--- a/server/common/user_test.go
+++ b/server/common/user_test.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -18,10 +17,27 @@ func TestUserNewToken(t *testing.T) {
 
 func TestUser_String(t *testing.T) {
 	user := NewUser(ProviderLocal, "user")
-	user.Name = "user"
+	user.Name = "John Doe"
 	user.Login = "user"
 	user.Email = "user@root.gg"
-	fmt.Println(user.String())
+	require.Equal(t, "local:user John Doe user@root.gg", user.String())
+}
+
+func TestUser_String_OIDC(t *testing.T) {
+	// OIDC users are keyed by the sub claim, the login holds preferred_username.
+	// The list output must show the real ID so it can be used with --login.
+	user := NewUser(ProviderOIDC, "8f9d056a-1dab-3192-f1ae-552e024d948e")
+	user.Login = "test_user"
+	user.Name = "Test User"
+	user.Email = "primary@email.com"
+	require.Equal(t, "oidc:8f9d056a-1dab-3192-f1ae-552e024d948e test_user Test User primary@email.com", user.String())
+}
+
+func TestUser_String_EmptyID(t *testing.T) {
+	// A user built without an ID (e.g. constructed directly) must still fall
+	// back to provider:login rather than emitting a leading space.
+	user := &User{Provider: ProviderLocal, Login: "user"}
+	require.Equal(t, "local:user", user.String())
 }
 
 func TestIsValidProvider(t *testing.T) {


### PR DESCRIPTION
## Description

### What
Fixes the `plikd` CLI so OIDC users can actually be targeted by `user show/update/delete` and `token create`.

### Why
OIDC users are keyed by the `sub` claim, while their `login` holds `preferred_username`. Every other provider keeps the invariant `ID == provider:login` (google→email, github→login, ovh→nichandle), but OIDC breaks it. As a result:

- `plikd user list` printed `oidc:<login>` (e.g. `oidc:test_user`)
- but `user show/update/delete` and `token create` looked up `oidc:<login>` as the primary key, which never matched the stored `oidc:<sub>` row

So `plikd user update --provider oidc --login test_user --admin` failed with `User oidc:test_user not found` even though the user showed up in `user list`. The admin panel worked because it operates on the real user ID.

### Changes
- **`server/common/user.go`** — `User.String()` (used by `user list`) now prints the real user ID, appending the login when it differs from `provider:login` (the OIDC case), and falls back to `provider:login` when `ID` is unset. Output is byte-identical for local/google/github/ovh.
- **`server/cmd/user.go` / `server/cmd/token.go`** — extracted a shared `userNotFoundError()` helper; for OIDC it hints to run `plikd user list` and pass the ID after `oidc:` as `--login`.
- **`docs/operations/server-cli.md`** — documented the OIDC `sub` identifier with a copy-paste example.

### Testing
- New unit tests (TDD): `TestUser_String`, `TestUser_String_OIDC`, `TestUser_String_EmptyID`, and `TestUserNotFoundError` (first test in the `cmd` package).
- `make lint`, `make client server`, and `make docs` all pass; `server/common` passes under `-race`.
- Manually verified end-to-end against a sqlite-backed `plikd`: seeded an OIDC user keyed by a `sub`-style UUID with `login=test_user`, confirmed `user list` shows the real ID, `user update --login <sub> --admin` persists, the old `--login test_user` path now prints the hint, and `token create`/`user delete` behave the same.